### PR TITLE
fix(entity): credencial canonica inclui advisor de IA da Nuvini (NVNI)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ Ao tocar em qualquer lógica sensível a autor/domínio/padrão editorial: passe
 - Exceção: código, variáveis, commits, nomes de arquivo em inglês
 
 ### Nomenclatura (cliente `default`)
-- Credencial canônica: "Alexandre Caramaschi — CEO da Brasil GEO, ex-CMO da Semantix (Nasdaq), cofundador da AI Brasil"
+- Credencial canônica: "Alexandre Caramaschi — CEO da Brasil GEO, ex-CMO da Semantix (Nasdaq), advisor estratégico de IA da Nuvini (Nasdaq: NVNI), cofundador da AI Brasil"
 - NUNCA usar: "Especialista #1", "GEO Brasil", "Source Rank"
 - Domínios válidos: alexandrecaramaschi.com, brasilgeo.ai
 - NUNCA referenciar: geobrasil.com.br, sourcerank.ai
@@ -235,7 +235,7 @@ python cli.py batch config/courses.yaml --client X   # Lote sob cliente X
 
 ## Credencial do Autor (cliente `default`)
 - Nome: Alexandre Caramaschi
-- Título: CEO da Brasil GEO, ex-CMO da Semantix (Nasdaq), cofundador da AI Brasil
+- Título: CEO da Brasil GEO, ex-CMO da Semantix (Nasdaq), advisor estratégico de IA da Nuvini (Nasdaq: NVNI), cofundador da AI Brasil
 - URL: https://alexandrecaramaschi.com
 - NUNCA usar: "Especialista #1", credenciais inventadas
 

--- a/README.md
+++ b/README.md
@@ -501,7 +501,7 @@ curso-factory/
 
 ## Autor
 
-**Alexandre Caramaschi** — CEO da Brasil GEO, ex-CMO da Semantix (Nasdaq), cofundador da AI Brasil.
+**Alexandre Caramaschi** — CEO da Brasil GEO, ex-CMO da Semantix (Nasdaq), advisor estratégico de IA da Nuvini (Nasdaq: NVNI), cofundador da AI Brasil.
 
 - [alexandrecaramaschi.com](https://alexandrecaramaschi.com)
 - [LinkedIn](https://www.linkedin.com/in/alexandrecaramaschi/)

--- a/config/clients/default/client.yaml
+++ b/config/clients/default/client.yaml
@@ -9,7 +9,7 @@ id: default
 # Autoria e credenciais canônicas
 author:
   name: "Alexandre Caramaschi"
-  credential: "CEO da Brasil GEO, ex-CMO da Semantix (Nasdaq), cofundador da AI Brasil"
+  credential: "CEO da Brasil GEO, ex-CMO da Semantix (Nasdaq), advisor estratégico de IA da Nuvini (Nasdaq: NVNI), cofundador da AI Brasil"
   title_seo_suffix: "Alexandre Caramaschi"
 
 # Empresa — aparece como provider no schema.org e no bloco de autoria

--- a/output/drafts/escrita-academica-profunda-geo_modulos-1-6-expanded.md
+++ b/output/drafts/escrita-academica-profunda-geo_modulos-1-6-expanded.md
@@ -1,6 +1,6 @@
 # Escrita Acadêmica Profunda para Publicação em GEO e LLM Research
 
-**Autor:** Alexandre Caramaschi — CEO da Brasil GEO, ex-CMO da Semantix (Nasdaq), cofundador da AI Brasil
+**Autor:** Alexandre Caramaschi — CEO da Brasil GEO, ex-CMO da Semantix (Nasdaq), advisor estratégico de IA da Nuvini (Nasdaq: NVNI), cofundador da AI Brasil
 
 **Escopo editorial:** curso avançado para pesquisadores aplicados (practitioners) que produzem pesquisa em Generative Engine Optimization, retrieval augmented generation e LLM research e querem publicar em SSRN, ArXiv (cs.IR), Zenodo, Semantic Scholar, workshops SIGIR/WWW e journals Q1 (Information Sciences, JASIST, IP&M).
 

--- a/src/models.py
+++ b/src/models.py
@@ -147,7 +147,7 @@ class CourseDefinition(BaseModel):
     # Defaults mantidos apenas para compatibilidade com fixtures antigas;
     # em uso real, SchemaBuilder.build(client=...) sobrescreve.
     autor_nome: str = "Alexandre Caramaschi"
-    autor_credencial: str = "CEO da Brasil GEO, ex-CMO da Semantix (Nasdaq), cofundador da AI Brasil"
+    autor_credencial: str = "CEO da Brasil GEO, ex-CMO da Semantix (Nasdaq), advisor estratégico de IA da Nuvini (Nasdaq: NVNI), cofundador da AI Brasil"
     dominio: str = "https://alexandrecaramaschi.com"
     educacao_path: str = "/educacao"
     # Empresa — schema.org provider e bloco de autoria

--- a/src/validators/test_voice_guard.py
+++ b/src/validators/test_voice_guard.py
@@ -43,7 +43,7 @@ Ao final deste modulo voce sera capaz de:
 
 A Brasil GEO eh a primeira consultoria brasileira especializada em
 Generative Engine Optimization. Fundada por Alexandre Caramaschi,
-CEO da Brasil GEO, ex-CMO da Semantix (Nasdaq), cofundador da AI Brasil.
+CEO da Brasil GEO, ex-CMO da Semantix (Nasdaq), advisor estratégico de IA da Nuvini (Nasdaq: NVNI), cofundador da AI Brasil.
 
 A pratica recente de instrumentacao de modelos LLM em pipelines de
 producao mostra que decisoes de roteamento por complexidade reduzem

--- a/tests/fixtures/sample_course.json
+++ b/tests/fixtures/sample_course.json
@@ -95,7 +95,7 @@
   "hero_gradient_from": "#032d60",
   "hero_gradient_to": "#0176d3",
   "autor_nome": "Alexandre Caramaschi",
-  "autor_credencial": "CEO da Brasil GEO, ex-CMO da Semantix (Nasdaq), cofundador da AI Brasil",
+  "autor_credencial": "CEO da Brasil GEO, ex-CMO da Semantix (Nasdaq), advisor estratégico de IA da Nuvini (Nasdaq: NVNI), cofundador da AI Brasil",
   "dominio": "https://alexandrecaramaschi.com",
   "badge_color": "#0176d3",
   "local_storage_key": "teste-geracao-course-progress",


### PR DESCRIPTION
Atualiza a credencial canonica de Alexandre Caramaschi para incluir 'advisor estrategico de IA da Nuvini (Nasdaq: NVNI)', consistente em config/client.yaml, models.py, README, CLAUDE.md, test_voice_guard e fixture. Substituicao identica de string. Termo advisor (nao conselheiro).

Co-Authored-By: Claude Opus 4.8 (1M context)