### PR TITLE
fix(template): renderer robusto + navegacao + visuais ricos (stat/flow) — frontend e correcoes sempre nos cursos

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ Ao tocar em qualquer lógica sensível a autor/domínio/padrão editorial: passe
 - Exceção: código, variáveis, commits, nomes de arquivo em inglês
 
 ### Nomenclatura (cliente `default`)
-- Credencial canônica: "Alexandre Caramaschi — CEO da Brasil GEO, ex-CMO da Semantix (Nasdaq), cofundador da AI Brasil"
+- Credencial canônica: "Alexandre Caramaschi — CEO da Brasil GEO, ex-CMO da Semantix (Nasdaq), advisor estratégico de IA da Nuvini (Nasdaq: NVNI), cofundador da AI Brasil"
 - NUNCA usar: "Especialista #1", "GEO Brasil", "Source Rank"
 - Domínios válidos: alexandrecaramaschi.com, brasilgeo.ai
 - NUNCA referenciar: geobrasil.com.br, sourcerank.ai
@@ -235,7 +235,7 @@ python cli.py batch config/courses.yaml --client X   # Lote sob cliente X
 
 ## Credencial do Autor (cliente `default`)
 - Nome: Alexandre Caramaschi
-- Título: CEO da Brasil GEO, ex-CMO da Semantix (Nasdaq), cofundador da AI Brasil
+- Título: CEO da Brasil GEO, ex-CMO da Semantix (Nasdaq), advisor estratégico de IA da Nuvini (Nasdaq: NVNI), cofundador da AI Brasil
 - URL: https://alexandrecaramaschi.com
 - NUNCA usar: "Especialista #1", credenciais inventadas
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,28 @@ O template `page.tsx.j2` inclui um componente `FormattedText` **robusto a markdo
 
 > **Contrato de renderização (não reintroduzir bugs):** qualquer um desses elementos SEMPRE renderiza corretamente, independente da convenção que o LLM gerar. Os bugs históricos — `##` aparecendo literal, bullets `- ` virando parágrafo, negrito/código cru dentro de callouts, crase literal — foram corrigidos no template em 2026-06. NUNCA voltar a um renderizador que só aceite `-- ` ou só headings com `:`, nem callouts que imprimam `section.value` cru.
 
+### Elementos visuais ricos (charts, fluxogramas, animações) — OBRIGATÓRIO usar
+
+O template (`page.tsx.j2`) já entrega **fora da caixa** dois elementos visuais animados, data-driven, que TODO curso deve aproveitar (não deixar módulos só com texto):
+
+- **`stat`** — cartões de número animado (`AnimatedCounter` + `framer-motion`). `section.value` é JSON:
+  ```json
+  [{ "value": "90", "suffix": " tok/s", "label": "throughput numa GPU de 8GB" }, { "value": "40", "suffix": "x", "label": "mais barato que a nuvem" }]
+  ```
+- **`flow`** — fluxograma animado (caixas + conectores). `section.value` é JSON:
+  ```json
+  { "title": "Como o roteador decide", "subtitle": "do prompt ao modelo certo", "steps": [{ "label": "Prompt", "tone": "neutral" }, { "label": "Classificador" }, { "label": "Resposta", "tone": "success" }] }
+  ```
+  `tone`: `accent` (padrão), `success`, `warning`, `neutral`.
+
+**Charts (recharts) e fluxos sofisticados específicos do tema:** crie um componente por-curso em `src/components/<slug-do-curso>/Visuals.tsx` (stack já disponível no repo de destino: **recharts**, **framer-motion**, **AnimatedCounter**) com um dispatcher `CourseVisual({ id })`, importe-o na página e acione via um section `image-placeholder`/`visual` apontando o id. Use tipos diversos de gráfico (barras, radar, área) e cores por categoria. Referência viva: `landing-page-geo/src/components/orquestracao-llm/CourseVisuals.tsx`.
+
+**Regra de densidade visual:** nenhum módulo deve ficar só com texto/código. Cada módulo deve ter ao menos **1 elemento visual** (tabela, `stat`, `flow`, `diagram` ASCII ou chart), e os módulos finais (troubleshooting, FAQ, glossário) também — não concentrar tudo no começo.
+
+### Navegação dos módulos (accordion) — comportamento correto
+
+Ao abrir um módulo, o cabeçalho é **alinhado no topo** (abaixo das barras fixas) via `focusStep()` + `scrollMarginTop: 120px` + `scrollIntoView({ block: "start" })`, com um `setTimeout(90ms)` para o layout do accordion assentar antes do scroll. Isso corrige o bug histórico de "abrir no final" / sanfona janky. **NUNCA** voltar a um `toggleStep` que só faz `setOpenStep` sem realinhar o scroll, nem usar `block: "center"`.
+
 ### Expressões Proibidas
 - "nos dias de hoje", "é fundamental que", "não é segredo que"
 - "o futuro é agora", "em um mundo cada vez mais", "vamos explorar"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,23 +114,26 @@ Ao tocar em qualquer lógica sensível a autor/domínio/padrão editorial: passe
 ### Formatação Obrigatória por Módulo
 - Ao menos 1 tabela comparativa (formato markdown com pipes)
 - Ao menos 3 exercícios com contexto profissional e progressão Bloom
-- Sub-headings (linha terminando com `:`) a cada 2-3 parágrafos
-- Negrito em termos-chave na primeira ocorrência usando `**termo**`
+- Sub-headings com `## ` (markdown) OU linha terminando com `:` — ambos renderizam — a cada 2-3 parágrafos
+- Negrito em termos-chave na primeira ocorrência usando `**termo**`; código, comandos e variáveis entre crases `` `assim` `` (renderizam como código inline estilizado)
 - Blockquotes (`> `) para insights centrais — ao menos 1-2 por módulo
-- Bullets com `-- ` (dois hífens), NUNCA `- ` (um hífen)
+- Bullets com `- ` ou `-- ` (ambos renderizam); listas numeradas com `1. `
 - Nunca mais de 3 parágrafos seguidos sem elemento visual
 - 2.500-4.000 palavras por módulo
 
 ### Padrão de Layout (FormattedText — UX Microsoft Learn + Salesforce Trailhead)
-O template `page.tsx.j2` inclui um componente `FormattedText` que renderiza:
-- `**bold**` → `<strong>` com font-semibold
-- Linha terminando com `:` → `<h4>` sub-heading com border-bottom
-- `-- item` → bullet list com dot azul (accent color)
+O template `page.tsx.j2` inclui um componente `FormattedText` **robusto a markdown padrão** que renderiza:
+- `**bold**` → `<strong>` com font-semibold; `` `codigo` `` (crases) → `<code>` inline estilizado
+- `# `, `## `, `### ` (markdown) **E** linha terminando com `:` → `<h4>` sub-heading com border-bottom
+- `- item`, `* item` e o legado `-- item` → bullet list com dot azul (accent color)
 - `1. item` → ordered list com número azul
 - `| col | col |` → `<table>` com header uppercase e zebra striping
 - `> texto` → blockquote com borda lateral azul
 - Parágrafos → text-justify com leading-[1.75]
-- Warning/tip/checkpoint → text-justify aplicado
+- `warning` / `tip` / `checkpoint` → renderizam **negrito**, `` `codigo` `` e quebras de linha (via `renderInline` + `whitespace-pre-line`)
+- `diagram` (com `label`) → figura ASCII emoldurada com legenda; `image-placeholder` (com `label`) → figura ilustrativa
+
+> **Contrato de renderização (não reintroduzir bugs):** qualquer um desses elementos SEMPRE renderiza corretamente, independente da convenção que o LLM gerar. Os bugs históricos — `##` aparecendo literal, bullets `- ` virando parágrafo, negrito/código cru dentro de callouts, crase literal — foram corrigidos no template em 2026-06. NUNCA voltar a um renderizador que só aceite `-- ` ou só headings com `:`, nem callouts que imprimam `section.value` cru.
 
 ### Expressões Proibidas
 - "nos dias de hoje", "é fundamental que", "não é segredo que"

--- a/README.md
+++ b/README.md
@@ -501,7 +501,7 @@ curso-factory/
 
 ## Autor
 
-**Alexandre Caramaschi** — CEO da Brasil GEO, ex-CMO da Semantix (Nasdaq), cofundador da AI Brasil.
+**Alexandre Caramaschi** — CEO da Brasil GEO, ex-CMO da Semantix (Nasdaq), advisor estratégico de IA da Nuvini (Nasdaq: NVNI), cofundador da AI Brasil.
 
 - [alexandrecaramaschi.com](https://alexandrecaramaschi.com)
 - [LinkedIn](https://www.linkedin.com/in/alexandrecaramaschi/)

--- a/config/clients/default/client.yaml
+++ b/config/clients/default/client.yaml
@@ -9,7 +9,7 @@ id: default
 # Autoria e credenciais canônicas
 author:
   name: "Alexandre Caramaschi"
-  credential: "CEO da Brasil GEO, ex-CMO da Semantix (Nasdaq), cofundador da AI Brasil"
+  credential: "CEO da Brasil GEO, ex-CMO da Semantix (Nasdaq), advisor estratégico de IA da Nuvini (Nasdaq: NVNI), cofundador da AI Brasil"
   title_seo_suffix: "Alexandre Caramaschi"
 
 # Empresa — aparece como provider no schema.org e no bloco de autoria

--- a/output/drafts/escrita-academica-profunda-geo_modulos-1-6-expanded.md
+++ b/output/drafts/escrita-academica-profunda-geo_modulos-1-6-expanded.md
@@ -1,6 +1,6 @@
 # Escrita Acadêmica Profunda para Publicação em GEO e LLM Research
 
-**Autor:** Alexandre Caramaschi — CEO da Brasil GEO, ex-CMO da Semantix (Nasdaq), cofundador da AI Brasil
+**Autor:** Alexandre Caramaschi — CEO da Brasil GEO, ex-CMO da Semantix (Nasdaq), advisor estratégico de IA da Nuvini (Nasdaq: NVNI), cofundador da AI Brasil
 
 **Escopo editorial:** curso avançado para pesquisadores aplicados (practitioners) que produzem pesquisa em Generative Engine Optimization, retrieval augmented generation e LLM research e querem publicar em SSRN, ArXiv (cs.IR), Zenodo, Semantic Scholar, workshops SIGIR/WWW e journals Q1 (Information Sciences, JASIST, IP&M).
 

--- a/src/models.py
+++ b/src/models.py
@@ -147,7 +147,7 @@ class CourseDefinition(BaseModel):
     # Defaults mantidos apenas para compatibilidade com fixtures antigas;
     # em uso real, SchemaBuilder.build(client=...) sobrescreve.
     autor_nome: str = "Alexandre Caramaschi"
-    autor_credencial: str = "CEO da Brasil GEO, ex-CMO da Semantix (Nasdaq), cofundador da AI Brasil"
+    autor_credencial: str = "CEO da Brasil GEO, ex-CMO da Semantix (Nasdaq), advisor estratégico de IA da Nuvini (Nasdaq: NVNI), cofundador da AI Brasil"
     dominio: str = "https://alexandrecaramaschi.com"
     educacao_path: str = "/educacao"
     # Empresa — schema.org provider e bloco de autoria

--- a/src/templates/page.tsx.j2
+++ b/src/templates/page.tsx.j2
@@ -6,9 +6,11 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { motion } from "framer-motion";
 import Topbar from "@/components/Topbar";
 import Breadcrumbs from "@/components/Breadcrumbs";
 import Footer from "@/components/Footer";
+import AnimatedCounter from "@/components/AnimatedCounter";
 
 /* ───────── TYPES ───────── */
 interface Step {
@@ -21,7 +23,7 @@ interface Step {
 }
 
 interface Section {
-  type: "text" | "code" | "warning" | "tip" | "checkpoint" | "image-placeholder" | "diagram";
+  type: "text" | "code" | "warning" | "tip" | "checkpoint" | "image-placeholder" | "diagram" | "stat" | "flow";
   value: string;
   language?: string;
   label?: string;
@@ -514,6 +516,70 @@ function FormattedText({ value }: { value: string }) {
   return <div className="text-[var(--text)] text-[15px]">{elements}</div>;
 }
 
+/* ───────── RICH VISUAL BLOCKS (animados / fluxogramas, data-driven) ─────────
+   stat:  section.value = JSON [{ "value": "90", "suffix": " tok/s", "label": "..." }]
+   flow:  section.value = JSON { "title?": "", "subtitle?": "", "steps": [{ "label": "", "tone?": "accent|success|warning|neutral" }] }
+   Para charts (recharts) use um componente por-curso wired num section "image-placeholder"
+   ou crie src/components/<curso>/Visuals.tsx — ver CLAUDE.md (Elementos visuais ricos). */
+{% raw %}
+function safeJson<T>(s: string, fallback: T): T {
+  try { return JSON.parse(s) as T; } catch { return fallback; }
+}
+
+const FADE_IN = {
+  initial: { opacity: 0, y: 16 },
+  whileInView: { opacity: 1, y: 0 },
+  viewport: { once: true, amount: 0.2 },
+  transition: { duration: 0.5, ease: "easeOut" as const },
+};
+
+function StatBlock({ value }: { value: string }) {
+  const items = safeJson<{ value: string; suffix?: string; label: string }[]>(value, []);
+  if (!items.length) return null;
+  return (
+    <motion.div {...FADE_IN} className="grid grid-cols-2 lg:grid-cols-4 gap-3 my-5">
+      {items.map((s, i) => (
+        <div key={i} className="rounded-xl border p-4 text-center" style={{ borderColor: "var(--border-light)", background: "var(--bg-muted)" }}>
+          <div className="text-2xl font-extrabold" style={{ color: "var(--accent)" }}>
+            <AnimatedCounter value={s.value} />{s.suffix || ""}
+          </div>
+          <div className="text-[11px] mt-1 leading-snug" style={{ color: "var(--text-muted)" }}>{s.label}</div>
+        </div>
+      ))}
+    </motion.div>
+  );
+}
+
+const FLOW_TONES: Record<string, { c: string; bg: string }> = {
+  accent: { c: "var(--accent)", bg: "var(--accent-lighter)" },
+  success: { c: "var(--success)", bg: "var(--success-light)" },
+  warning: { c: "#b45309", bg: "#fff8e1" },
+  neutral: { c: "#0f172a", bg: "var(--bg-muted)" },
+};
+
+function FlowBlock({ value }: { value: string }) {
+  const flow = safeJson<{ title?: string; subtitle?: string; steps: { label: string; tone?: string }[] }>(value, { steps: [] });
+  if (!flow.steps?.length) return null;
+  return (
+    <motion.div {...FADE_IN} className="rounded-2xl bg-white border p-5 sm:p-6 my-5" style={{ borderColor: "var(--border)" }}>
+      {flow.title && <h3 className="text-[15px] font-bold mb-1" style={{ color: "var(--text)" }}>{flow.title}</h3>}
+      {flow.subtitle && <p className="text-xs mb-4" style={{ color: "var(--text-muted)" }}>{flow.subtitle}</p>}
+      <div className="max-w-md mx-auto">
+        {flow.steps.map((st, i) => {
+          const t = FLOW_TONES[st.tone || "accent"] || FLOW_TONES.accent;
+          return (
+            <div key={i}>
+              <div className="rounded-lg px-3 py-2 text-center text-[12px] font-semibold border" style={{ color: t.c, background: t.bg, borderColor: "var(--border-light)" }}>{st.label}</div>
+              {i < flow.steps.length - 1 && <div className="mx-auto my-1.5 h-4 w-px" style={{ background: "#cbd5e1" }} aria-hidden />}
+            </div>
+          );
+        })}
+      </div>
+    </motion.div>
+  );
+}
+{% endraw %}
+
 /* ───────── COMPONENT: StepCard ───────── */
 function StepCard({
   step,
@@ -533,6 +599,7 @@ function StepCard({
   return (
     <div
       id={step.id}
+      style={% raw %}{{ scrollMarginTop: "120px" }}{% endraw %}
       className={`rounded-[var(--radius-lg)] border transition-all duration-300 ${
         isOpen
           ? "border-[var(--accent)] shadow-lg"
@@ -633,6 +700,10 @@ function StepCard({
                       </div>
                     </figure>
                   );
+                case "stat":
+                  return <StatBlock key={i} value={section.value} />;
+                case "flow":
+                  return <FlowBlock key={i} value={section.value} />;
                 default:
                   return null;
               }
@@ -709,8 +780,20 @@ export default function {{ component_name }}() {
     }
   }, [completed]);
 
+  const focusStep = (id: string) => {
+    setOpenStep(id);
+    // espera o accordion expandir/colapsar antes de alinhar o cabecalho no topo
+    window.setTimeout(() => {
+      document.getElementById(id)?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }, 90);
+  };
+
   const toggleStep = (id: string) => {
-    setOpenStep(openStep === id ? null : id);
+    if (openStep === id) {
+      setOpenStep(null);
+    } else {
+      focusStep(id);
+    }
   };
 
   const completeStep = (id: string) => {
@@ -722,7 +805,7 @@ export default function {{ component_name }}() {
       // Open next step
       const currentIndex = STEPS.findIndex((s) => s.id === id);
       if (currentIndex < STEPS.length - 1) {
-        setOpenStep(STEPS[currentIndex + 1].id);
+        focusStep(STEPS[currentIndex + 1].id);
       }
     }
     setCompleted(next);
@@ -832,10 +915,7 @@ export default function {{ component_name }}() {
                     {STEPS.map((step, i) => (
                       <button
                         key={step.id}
-                        onClick={() => {
-                          setOpenStep(step.id);
-                          document.getElementById(step.id)?.scrollIntoView({ behavior: "smooth", block: "center" });
-                        }}
+                        onClick={() => focusStep(step.id)}
                         className={`w-full text-left flex items-center gap-3 px-3 py-2.5 rounded-[var(--radius)] text-sm transition-colors ${
                           openStep === step.id
                             ? "bg-[var(--accent-lighter)] text-[var(--accent)] font-semibold"

--- a/src/templates/page.tsx.j2
+++ b/src/templates/page.tsx.j2
@@ -21,7 +21,7 @@ interface Step {
 }
 
 interface Section {
-  type: "text" | "code" | "warning" | "tip" | "checkpoint" | "image-placeholder";
+  type: "text" | "code" | "warning" | "tip" | "checkpoint" | "image-placeholder" | "diagram";
   value: string;
   language?: string;
   label?: string;
@@ -250,7 +250,7 @@ const STEPS: Step[] = [
 {% if section.type == "code" %}
       { type: "code", value: "{{ section.value | js_escape }}", language: "{{ section.language | default('text') }}" },
 {% else %}
-      { type: "{{ section.type }}", value: "{{ section.value | js_escape }}" },
+      { type: "{{ section.type }}", value: "{{ section.value | js_escape }}"{% if section.label %}, label: "{{ section.label | js_escape }}"{% endif %} },
 {% endif %}
 {% endfor %}
     ],
@@ -316,10 +316,13 @@ function CodeBlock({ code, language }: { code: string; language?: string }) {
 
 /* ───────── RICH TEXT RENDERER ───────── */
 function renderInline(str: string): React.ReactNode[] {
-  const parts = str.split(/(\*\*.*?\*\*)/g);
+  const parts = str.split(/(\*\*[^*]+\*\*|`[^`]+`)/g);
   return parts.map((part, i) => {
     if (part.startsWith("**") && part.endsWith("**")) {
       return <strong key={i} className="font-semibold text-[var(--text)]">{part.slice(2, -2)}</strong>;
+    }
+    if (part.length > 2 && part.startsWith("`") && part.endsWith("`")) {
+      return <code key={i} className="px-1.5 py-0.5 rounded bg-[var(--bg-muted)] text-[var(--accent)] text-[0.88em] font-mono">{part.slice(1, -1)}</code>;
     }
     return <span key={i}>{part}</span>;
   });
@@ -428,6 +431,23 @@ function FormattedText({ value }: { value: string }) {
     }
     flushTable();
 
+    /* Markdown header (#, ##, ###, ####) \u2014 robusto a markdown padrao */
+    const hMatch = trimmed.match(/^(#{1,4})\s+(.+)$/);
+    if (hMatch) {
+      flushBullets();
+      flushNums();
+      const lvl = hMatch[1].length;
+      elements.push(
+        <h4
+          key={`mh-${j}`}
+          className={`font-bold text-[var(--text)] mb-2 pb-1.5 border-b border-[var(--border-light)] ${lvl <= 2 ? "text-[17px] mt-7" : "text-[15px] mt-5"}`}
+        >
+          {renderInline(hMatch[2])}
+        </h4>
+      );
+      continue;
+    }
+
     /* Section heading (line ending with :) */
     if (
       trimmed.match(/^[A-Z\u00C0-\u024F\d].{3,100}:\s*$/) &&
@@ -462,10 +482,11 @@ function FormattedText({ value }: { value: string }) {
       continue;
     }
 
-    /* Bullet point */
-    if (trimmed.startsWith("-- ") || trimmed.startsWith("--")) {
+    /* Bullet point — aceita "- ", "* " e o legado "-- " */
+    const bulletMatch = trimmed.match(/^(?:--?|\*)\s+(.+)$/);
+    if (bulletMatch) {
       flushNums();
-      bulletBuffer.push({ key: j, text: trimmed.replace(/^--\s*/, "") });
+      bulletBuffer.push({ key: j, text: bulletMatch[1] });
       continue;
     }
     flushBullets();
@@ -571,14 +592,14 @@ function StepCard({
                   return (
                     <div key={i} className="flex gap-3 p-4 rounded-[var(--radius)] bg-[#fff8e1] border border-[#ffe082]">
                       <span className="flex-shrink-0 mt-0.5">{icons.alertTriangle}</span>
-                      <p className="text-sm text-[#5d4037] leading-relaxed text-justify">{section.value}</p>
+                      <p className="text-sm text-[#5d4037] leading-relaxed text-justify whitespace-pre-line">{renderInline(section.value)}</p>
                     </div>
                   );
                 case "tip":
                   return (
                     <div key={i} className="flex gap-3 p-4 rounded-[var(--radius)] bg-[var(--accent-lighter)] border border-[var(--accent)]/20">
                       <span className="flex-shrink-0 mt-0.5">{icons.lightbulb}</span>
-                      <p className="text-sm text-[var(--accent-dark)] leading-relaxed text-justify">{section.value}</p>
+                      <p className="text-sm text-[var(--accent-dark)] leading-relaxed text-justify whitespace-pre-line">{renderInline(section.value)}</p>
                     </div>
                   );
                 case "checkpoint":
@@ -587,9 +608,30 @@ function StepCard({
                       <span className="flex-shrink-0 mt-0.5">{icons.circleCheck}</span>
                       <div>
                         <span className="text-xs font-bold text-[var(--success)] uppercase tracking-wider block mb-1">Checkpoint</span>
-                        <p className="text-sm text-[var(--success)] leading-relaxed text-justify">{section.value}</p>
+                        <p className="text-sm text-[var(--success)] leading-relaxed text-justify whitespace-pre-line">{renderInline(section.value)}</p>
                       </div>
                     </div>
+                  );
+                case "diagram":
+                  return (
+                    <figure key={i} className="my-5">
+                      <div className="overflow-x-auto rounded-[var(--radius)] border border-[var(--border)] bg-[#0c1e3e] p-4">
+                        <pre className="text-[12px] leading-[1.5] text-indigo-100 font-mono whitespace-pre">{section.value}</pre>
+                      </div>
+                      {section.label && (
+                        <figcaption className="mt-2 text-center text-xs text-[var(--text-light)]">{`Figura - ${section.label}`}</figcaption>
+                      )}
+                    </figure>
+                  );
+                case "image-placeholder":
+                  return (
+                    <figure key={i} className="my-5">
+                      <div className="flex flex-col items-center justify-center gap-2 rounded-[var(--radius)] border-2 border-dashed border-[var(--accent)]/30 bg-[var(--accent)]/5 py-8 px-4 text-center">
+                        <span className="text-[var(--accent)]">{icons.layers}</span>
+                        <p className="text-sm font-semibold text-[var(--text)]">{section.label || "Ilustração"}</p>
+                        <p className="text-xs text-[var(--text-muted)] max-w-md">{section.value}</p>
+                      </div>
+                    </figure>
                   );
                 default:
                   return null;

--- a/src/validators/test_voice_guard.py
+++ b/src/validators/test_voice_guard.py
@@ -43,7 +43,7 @@ Ao final deste modulo voce sera capaz de:
 
 A Brasil GEO eh a primeira consultoria brasileira especializada em
 Generative Engine Optimization. Fundada por Alexandre Caramaschi,
-CEO da Brasil GEO, ex-CMO da Semantix (Nasdaq), cofundador da AI Brasil.
+CEO da Brasil GEO, ex-CMO da Semantix (Nasdaq), advisor estratégico de IA da Nuvini (Nasdaq: NVNI), cofundador da AI Brasil.
 
 A pratica recente de instrumentacao de modelos LLM em pipelines de
 producao mostra que decisoes de roteamento por complexidade reduzem

--- a/tests/fixtures/sample_course.json
+++ b/tests/fixtures/sample_course.json
@@ -95,7 +95,7 @@
   "hero_gradient_from": "#032d60",
   "hero_gradient_to": "#0176d3",
   "autor_nome": "Alexandre Caramaschi",
-  "autor_credencial": "CEO da Brasil GEO, ex-CMO da Semantix (Nasdaq), cofundador da AI Brasil",
+  "autor_credencial": "CEO da Brasil GEO, ex-CMO da Semantix (Nasdaq), advisor estratégico de IA da Nuvini (Nasdaq: NVNI), cofundador da AI Brasil",
   "dominio": "https://alexandrecaramaschi.com",
   "badge_color": "#0176d3",
   "local_storage_key": "teste-geracao-course-progress",


### PR DESCRIPTION
Corrige na RAIZ os bugs de formatacao que se repetiam em cursos gerados a partir do `page.tsx.j2`:

- **Headers**: `FormattedText` agora trata `#`/`##`/`###`/`####` (antes `##` aparecia literal no texto).
- **Bullets**: aceitam `- `, `* ` e o legado `-- ` (antes so `-- `; `- ` virava paragrafo com hifen solto).
- **Codigo inline**: `renderInline` trata crases `` `assim` `` -> `<code>` estilizado (antes a crase aparecia literal).
- **Callouts** (`warning`/`tip`/`checkpoint`): renderizam **negrito**, codigo inline e quebras de linha via `renderInline` + `whitespace-pre-line` (antes imprimiam `section.value` cru).
- **Novos tipos**: `diagram` (figura ASCII emoldurada com legenda) e `image-placeholder`, com suporte a `label` no loop de dados Jinja.
- **CLAUDE.md**: secao "Contrato de renderizacao" documentada; regra "NUNCA `- `" relaxada (ambas convencoes renderizam).

Validacao: `jinja2.Environment().parse()` OK; fixes confirmados no template. Todo curso futuro herda o renderizador correto, sem reincidencia dos bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)