### PR TITLE
chore(memory): camada de memória de decisões + enxuga CLAUDE.md

### DIFF
--- a/.claude/hooks/capture_candidate.py
+++ b/.claude/hooks/capture_candidate.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""
+Captura passiva (candidate-gate) — hook Stop do Claude Code.
+
+Ao fim de cada sessao, registra um marcador de rascunho em
+<decisions>/candidates/_candidate_YYYY-MM-DD.md, para lembrar de DESTILAR os
+aprendizados da sessao numa decisao real (ver <decisions>/README.md).
+
+Principios (do setup de Memoria Persistente):
+- Rascunho NAO e autoritativo. A pasta candidates/ e gitignored.
+- O hook FALHA EM SILENCIO: nunca bloqueia o agente (sempre exit 0).
+- 1 arquivo por dia, 1 linha por sessao — leve, sem explosao de arquivos.
+"""
+import sys
+import os
+import json
+from datetime import datetime, timezone
+
+
+def main():
+    raw = ""
+    try:
+        if not sys.stdin.isatty():
+            raw = sys.stdin.read()
+    except Exception:
+        raw = ""
+
+    data = {}
+    try:
+        data = json.loads(raw) if raw.strip() else {}
+    except Exception:
+        data = {}
+
+    cwd = data.get("cwd") or os.getcwd()
+    session = (data.get("session_id") or "")[:8] or "sessao"
+
+    base = None
+    for candidate_dir in ("governance/decisions", "wiki/decisions"):
+        path = os.path.join(cwd, candidate_dir)
+        if os.path.isdir(path):
+            base = path
+            break
+    if base is None:
+        return  # repo sem a camada de decisoes; nada a capturar
+
+    cands = os.path.join(base, "candidates")
+    os.makedirs(cands, exist_ok=True)
+
+    now = datetime.now(timezone.utc).astimezone()
+    day = now.strftime("%Y-%m-%d")
+    stamp = now.strftime("%H:%M %z")
+    out = os.path.join(cands, "_candidate_" + day + ".md")
+
+    is_new = not os.path.exists(out)
+    with open(out, "a", encoding="utf-8") as fh:
+        if is_new:
+            fh.write("# Rascunhos de captura — " + day + "\n\n")
+            fh.write(
+                "> NÃO autoritativo (candidate-gate). Destile o que valer numa "
+                "decisão real via `../_TEMPLATE.md`, registre em `../INDEX.md` e "
+                "apague a linha aqui.\n\n"
+            )
+        fh.write(
+            "- [ ] " + stamp + " — sessão `" + session + "` encerrada. "
+            "Surgiu algum padrão, erro-a-evitar ou decisão a registrar?\n"
+        )
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        pass
+    sys.exit(0)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python .claude/hooks/capture_candidate.py",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,9 @@ node_modules/
 # OS
 .DS_Store
 Thumbs.db
+
+# Memoria de decisoes — rascunhos locais de captura (candidate-gate), nao autoritativos
+wiki/decisions/candidates/
+# Claude Code — estado local (settings.json e versionado de proposito)
+.claude/worktrees/
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,27 @@
 # curso-factory — Instruções Claude Code
 
+## Memória de decisões do projeto
+
+Decisões de arquitetura, erros-a-evitar e insights vivem em `wiki/decisions/` como
+arquivos `.md` versionados — a fonte da verdade, com índice navegável em
+[`wiki/decisions/INDEX.md`](wiki/decisions/INDEX.md) (inclui os ADRs existentes).
+Formato: **Verdade Compilada** (topo, reescrito quando o entendimento muda) + **Linha
+do Tempo** (append-only). Guia e template em `wiki/decisions/README.md`.
+
+Três disciplinas ao registrar conhecimento:
+1. **Dedup antes de gravar** — se a decisão já existe, atualize-a; não duplique.
+2. **Cross-link na escrita** — toda decisão nova linka 2-3 relacionadas via `[[nome]]`.
+3. **Candidate-gate** — o hook de fim de sessão rascunha em `candidates/` (não
+   versionado, não autoritativo); promova destilando numa decisão real.
+
+Orçamento de contexto: cada linha do `INDEX.md` < ~200 caracteres; o detalhe mora no
+arquivo da decisão, nunca no índice. O histórico datado de abril/2026 foi movido para
+`wiki/decisions/CLAUDE-CHANGELOG.md`.
+
 ## REGRA #0 — IDIOMA
 
 Todo conteúdo gerado pelo orquestrador em PT-BR com acentuação completa. Exceção: código, commits, docstrings, identifiers técnicos.
+
 
 ## REGRA #1 — Contexto enriquecido GEO/SEO 2026 (mandatório)
 
@@ -50,6 +69,7 @@ Em **toda** decisão de arquitetura do orquestrador, escolha de prompts por agen
 
 Citar `§X.Y` dos KBs/INCREMENT/WAVE ao tomar decisões. **Em conflito, a Wave 15B (§8) prevalece.** Atualizar trimestralmente (próxima: agosto/2026).
 
+
 ## 2026-06-03 — Citabilidade GEO operacional + KB V3 (rubrica de redação que vira gate)
 
 Incremento que **fecha o gap** entre a doutrina de GEO (que o repo já tinha em profundidade) e o que o pipeline efetivamente produz e valida. Confronto de junho com o conhecimento mais novo dos repos irmãos (`landing-page-geo/docs`: AutoGEO, earned media, conceitos 51-63) confirmou que as promessas do log de 2026-05-20 ("como aplicar no pipeline") **nunca tinham sido implementadas** — só documentadas. Agora foram.
@@ -70,6 +90,7 @@ Incremento que **fecha o gap** entre a doutrina de GEO (que o repo já tinha em 
 
 **Aplicação no pipeline (atualizada):** o redator (GPT-4o) recebe a rubrica carimbada; o gate conta os mínimos; o classificador emite as tags GEO; o revisor (Claude) trata `[FALTA EVIDÊNCIA]` para garantir Cite Sources reais (GhostCite mostra 14-95% de citações fabricadas em LLM — fonte verificável virou diferencial de GEO, não só higiene). Para ligar em outro cliente: bloco `geo_2026` no `client.yaml`.
 
+
 ## 2026-05-20 — Incremento canônico pós Google I/O 2026 (SEO+GEO+AEO+B2A)
 
 Adicionado em `docs/SEO_GEO_INCREMENT_20260520.md` o material consolidado de 3 fontes canônicas datadas mai/2026 sobre o estado da arte SEO+GEO+AEO+B2A pós Google I/O 2026 (15-mai-2026). **Não substitui** os 5 docs canônicos existentes (`GEO_KNOWLEDGE_BASE_2026.md`, `_V2`, `SEO_KNOWLEDGE_BASE_2026.md`, `AI_DISCOVERY_STANDARDS_2026.md`, `GEO_50_CONCEITOS_CANONICAL.md`) — **complementa** com camada operacional: Master Prompt 5 Ondas executável, 38 camadas técnicas mapeadas, Princeton GEO playbook (lifts mensurados), Two-Phase JSON-LD theory, Entity Boundary Drift, 8 Query Fan-Out variant types de King, ASO/B2A com NLWeb+MCP, anti-padrões 2026 e templates prontos (robots.txt, JSON-LD, llms.txt).
@@ -82,90 +103,10 @@ Adicionado em `docs/SEO_GEO_INCREMENT_20260520.md` o material consolidado de 3 f
 - `content_checker.py`: validações opcionais Cite Sources count, Statistics count, Quotation count, Compression Fidelity, Schema-content parity (bloqueante)
 - `client.yaml`: campos `geo_2026.princeton_playbook_enabled`, `geo_2026.schema_authority_stack_enabled`, `geo_2026.b2a_pilot.{nlweb_endpoint,mcp_endpoint,openapi_spec_url}`
 
-## 2026-04-29 — Refactor profundo em 5 waves (base reusável para outros segmentos)
 
-Pivô para tornar o curso-factory base de arquitetura para portais educacionais em **outros segmentos**, sem fork. As waves:
+## Histórico (changelog)
 
-1. **Auditoria** — mapa de bugs (4 subcomandos do CLI quebrados por imports inexistentes), código morto (`unified_finops.py`, `_build_writer_context`), duplicações de prompt e divergências entre CLAUDE.md e código real.
-2. **Fundação** — CLI reescrito (`validate`, `cost-report`, `batch`, `cache-clear` agora funcionam; `cmd_cost_report` lê o log real do `CostTracker` em vez da API fictícia que existia antes). `writer.py` e `reviewer.py` adotam `**template_vars` para paridade com os outros 3 agents.
-3. **Consolidação** — `unified_finops.py` removido (zero referências). `Cache` plugado no `LLMClient` (cache hit antes de circuit/retry). Defaults "Alexandre Caramaschi" / "Brasil GEO" removidos de `models.py:CourseDefinition` (`""` em vez de hardcode — quem instancia injeta via `ClientContext`). `SchemaBuilder` ganha clamp `max(30, duracao)`. Scripts ad-hoc movidos para `scripts/legacy/`.
-4. **Testes** — bateria expandida de **24 → 74 testes**: `test_cli` (11), `test_parsers` (14), `test_converters` (7), `test_cost_cache` (8), `test_validators_smoke` (10). Cobre todos os 8 subcomandos, parser canônico, conversor de drafts, FinOps, accent_checker, quality_gate e voice_guard. Toda chamada `datetime.utcnow()` migrada para `datetime.now(timezone.utc)`.
-5. **Docs** — `docs/ARCHITECTURE.md` reescrito como guia portal-agnóstico (camadas, o que é reusável, o que é segmento-específico, gaps conhecidos). Para novo portal: copiar `config/clients/_template/`, preencher YAML, eventualmente ajustar prompts.
-
-**Estado final:** 74/74 pytest verde, 8/8 subcomandos do CLI funcionais, zero código morto detectado, zero default de identidade no model.
-
-## 2026-04-25 — Base de conhecimento GEO/AEO/Agentic Commerce
-
-Foi adicionada uma camada doutrinária permanente em [docs/knowledge/geo-aeo/](docs/knowledge/geo-aeo/) que sintetiza 25+ papers acadêmicos (2025–2026) em 30 instruções operacionais, 7 princípios mestres, 4 checklists e tabela de thresholds quantitativos.
-
-**Quando usar.** Cursos sobre GEO, AEO, marketing por IA, comércio agêntico, MCP/A2A, RAG, knowledge graphs ou qualquer tema correlato devem usar este corpus como fonte primária. Cada agente do pipeline tem responsabilidades específicas:
-
-- **Pesquisa (Perplexity)** → fontes-âncora aceitas em `50-fontes-e-links.md`. Toda afirmação factual deve casar com pelo menos um paper deste catálogo.
-- **Redação (GPT-4o)** → princípios de `00-principios-mestres.md`, estrutura TL;DR/BLUF de `31-checklist-reescrita.md`, densidade de entidades 1/100 palavras (Instrução 17).
-- **Análise (Gemini)** → verificar os 16 pilares de `30-checklist-auditoria-geo16.md` em cada módulo.
-- **Classificação (Groq)** → tags com termos canônicos do `02-glossario.md`.
-- **Revisão (Claude)** → varredura final contra `01-anti-patterns.md`.
-
-**Princípio operacional.** Em conflito entre uma diretiva tática e um princípio mestre, **prevalece o princípio mestre**. A tese central: *GEO técnico é necessário, não suficiente. Estrutura validável vence prosa eloquente. Mídia conquistada explica a maior parte da variância de citação. Agent legibility é a nova SEO.*
-
-**Manutenção.** Revisão trimestral. Novos papers entram simultaneamente em `2X-papers-bloco-*.md`, `40-thresholds-quantitativos.md` e `50-fontes-e-links.md`.
-
-## 2026-04-19 — Refactor multi-tenant (Ondas 1-5)
-
-### Mudança estrutural: ClientContext
-- **Antes:** credencial Alexandre, domínio `alexandrecaramaschi.com`, padrão HSM/HBR/MIT Sloan e regras do voice guard estavam **hardcoded** em `models.py`, `voice_guard.py`, `pyproject.toml`, etc. Rodar a fábrica para outro cliente exigia fork.
-- **Depois:** tudo que varia por cliente vem de `config/clients/<id>/client.yaml`. O framework carrega o YAML em um `ClientContext` (`src/clients/context.py`) e injeta em CourseFactory, Orchestrator, SchemaBuilder, QualityGate e voice_guard_check.
-- **Cliente `default`** preserva 100% do comportamento pré-refactor (Brasil GEO). Qualquer `<id>` diferente escreve em `output/clients/<id>/`.
-- **CLI:** `python cli.py create "Curso" --client minhaempresa` ou `export CURSO_FACTORY_CLIENT=<id>`.
-- **Como listar:** `python cli.py clients`.
-- **Playbook completo:** [docs/MULTI-CLIENT.md](docs/MULTI-CLIENT.md).
-
-### Consolidação técnica
-- **Parser compartilhado** `src/parsers/markdown_parser.py`: fonte única de `slugify`, `extract_module_blocks`, `parse_module_to_sections`. Antes, `schema_builder.py` e `draft_to_course.py` tinham implementações paralelas divergentes.
-- **Providers em YAML** `config/providers.yaml` + `src/providers.py`: pricing, endpoints, default_model e fallback. `llm_client.py` só orquestra — mudança de preço/modelo é edição YAML.
-- **Voice Guard no QualityGate**: agora é a 4ª camada bloqueante. Score < `client.voice_guard.min_score` (padrão 70) ou erro crítico → `aprovado=False`.
-
-### Limpeza
-- `.gitignore` exclui `output/`, `*.egg-info/`, `.pytest_cache/`, `.mypy_cache/`.
-- `tests/fixtures/sample_course.json`: `nivel` corrigido de `intermediario` → `intermediário` (5/5 testes voltaram a verde).
-- `src/indexer/course_indexer.py`: removido hardcode `C:/Sandyboxclaude/...`; lê `LANDING_PAGE_DIR` do env ou derive de path relativo.
-
-### Commits da refatoração
-- `d3c1077` — refactor: multi-tenancy via ClientContext + limpeza de fundação
-- `203f126` — refactor: consolidação técnica (markdown_parser, providers.yaml, voice_guard em QualityGate)
-
-### Regra para trabalhos futuros
-Ao tocar em qualquer lógica sensível a autor/domínio/padrão editorial: passe pelo `ClientContext`, **não** hardcode. Se precisar de uma constante que varia por cliente, é campo de YAML.
-
-## 2026-04-09 — Mudanças da auditoria de ecossistema (Wave D)
-
-### NOVO: course_id propagado em cost_tracker (F32)
-- **Commit:** `72ee757` — `feat(cost-tracker): propaga course_id em todas chamadas LLM`
-- **Antes:** `cost_tracker.track()` sempre recebia `course_id=""`, tornando IMPOSSÍVEL responder "qual curso custou X" no `cost-report` ou aplicar budget guard granular por curso.
-- **Depois:** `LLMClient.set_course_context(course_id)` é chamado pelo `Orchestrator.run()` no início. Todas as chamadas LLM subsequentes propagam automaticamente.
-- **Como usar:** `python cli.py cost-report` agora pode agrupar por `course_id`. `cost_tracker.get_course_total('llm-finops')` retorna dados precisos por curso.
-- **Compat backward:** se `set_course_context` não for chamado, comportamento idêntico ao anterior.
-
-## 2026-04-09 — Mudanças da auditoria de ecossistema (Wave A-C)
-
-### 1. CLI `drafts-to-tsx` (F12)
-- **Commit:** `bc2f36e` — `feat(cli): drafts-to-tsx`
-- **Arquivos:** `cli.py` (+novo subcomando), `src/converters/__init__.py`, `src/converters/draft_to_course.py`
-- **Uso:** `python cli.py drafts-to-tsx [--input output/drafts] [--output output/converted_from_drafts]`
-- **Resultado da execução desta sessão:** **12/12 drafts órfãos convertidos** para TSX deployable. Output em `output/converted_from_drafts/` com `page.tsx` + `layout.tsx` válidos por curso.
-- **Próximo passo do owner:** revisar manualmente cada `output/converted_from_drafts/{slug}/page.tsx`, decidir quais publicar, mover aprovados para `output/deployed/`, commit final.
-- **Cursos liberados:** automacao-com-n8n (×2), deploy-moderno, geo-para-educacao-financeira-40 e -sub-18, llm-finops (×2), mcp-avancado (×2), prompt-engineering-avancado, seo-e-geo-para-advogados, seo-e-geo-para-revendedoras-de-joias.
-- **Conversor é best-effort:** parseia markdown da etapa `review` (preferida) ou `draft` (fallback), splita por headings, gera CourseSections (TEXT, CODE, TIP, CHECKPOINT). Cursos com 1 step só (sem headings claros) são clamped para 30 min mínimo.
-
-### 2. Pre-commit secret_guard (F44)
-- **Commit:** `8638b3f` — `sec(precommit): instala secret_guard`
-- **Arquivos:** `.tools/secret_guard.py`, `.githooks/pre-commit`
-- **Já ativado** localmente
-
-### Achados pendentes neste repo
-
-- **F13 (CRÍTICO):** ~~`voice_guard.py` programático ainda não existe.~~ **RESOLVIDO** na onda 2026-04-09 (B-012) e depois parametrizado por ClientContext em 2026-04-19.
-- **F38 → BAIXO:** `curso-factory` chama LLMs direto em vez de usar `geo-orchestrator`. Crosscheck Gemini concordou que esse achado estava superdimensionado. Migração para SDK fica para uma onda futura.
+Mudanças aplicadas datadas de abril/2026 — refactors (multi-tenant, 5 waves), base de conhecimento GEO/AEO e auditorias (Waves A-D) — foram movidas para [`wiki/decisions/CLAUDE-CHANGELOG.md`](wiki/decisions/CLAUDE-CHANGELOG.md), mantendo este arquivo enxuto no contexto. As **regras vivas** seguem abaixo.
 
 ## Regras Fundamentais
 
@@ -188,6 +129,7 @@ Playbook canônico: **`docs/FRONTEND_PLAYBOOK.md`** — como este repo é um GER
 ### Sem Emojis
 - Proibido emojis em qualquer conteúdo de curso ou documentação
 
+
 ## Arquitetura do Pipeline
 
 5 LLMs com papéis fixos — NÃO interpretar como sub-agentes do Claude Code:
@@ -203,6 +145,7 @@ Playbook canônico: **`docs/FRONTEND_PLAYBOOK.md`** — como este repo é um GER
 - Para alterar o comportamento de um agente, edite o arquivo .md correspondente
 - Se o arquivo .md não existir, o agente usa o TEMPLATE inline como fallback
 - NUNCA duplicar instruções entre o prompt externo e o template inline
+
 
 ## Padrão Editorial — Regras de Qualidade
 
@@ -264,6 +207,7 @@ Todo conteúdo de texto gerado por este repositório (drafts → páginas) deve 
 - "como sabemos", "é importante ressaltar", "vale a pena destacar"
 - "grosso modo", "vamos aprender", "agora você vai entender"
 
+
 ## Quality Gate — 5 Camadas de Validação
 
 ### Camada 1: Acentuação (accent_checker.py)
@@ -300,6 +244,7 @@ Todo conteúdo de texto gerado por este repositório (drafts → páginas) deve 
 - O texto corrigido é retornado em `GateResult.texto_corrigido`
 - Correções residuais são detectadas e reportadas
 
+
 ## Regras Anti-Retrabalho
 
 ### NUNCA usar heredocs para conteúdo grande
@@ -322,6 +267,7 @@ Todo conteúdo de texto gerado por este repositório (drafts → páginas) deve 
 - Verificar custo antes de executar pipeline completo
 - API keys: fonte de verdade em geo-orchestrator/.env
 
+
 ## Estrutura de Arquivos
 
 - config/courses.yaml — definição dos cursos
@@ -337,6 +283,7 @@ Todo conteúdo de texto gerado por este repositório (drafts → páginas) deve 
 - output/deployed/ — em produção
 - tests/ — testes unitários dos geradores
 
+
 ## Comandos CLI
 
 ```bash
@@ -349,6 +296,7 @@ python cli.py batch config/courses.yaml              # Criação em lote
 python cli.py batch config/courses.yaml --client X   # Lote sob cliente X
 ```
 
+
 ## Workflow de Criação de Curso
 
 1. Definir curso em courses.yaml (nome, nível, módulos, descrição)
@@ -358,6 +306,7 @@ python cli.py batch config/courses.yaml --client X   # Lote sob cliente X
 5. Auto-correção de acentos aplicada
 6. Se aprovado → output/approved/
 7. Deploy manual ou via script
+
 
 ## Credencial do Autor (cliente `default`)
 - Nome: Alexandre Caramaschi

--- a/wiki/decisions/CLAUDE-CHANGELOG.md
+++ b/wiki/decisions/CLAUDE-CHANGELOG.md
@@ -1,0 +1,97 @@
+# CLAUDE-CHANGELOG — curso-factory
+
+Log datado de mudanças aplicadas, extraído do `CLAUDE.md` em 2026-06-15 para manter o arquivo de regras vivas enxuto (princípio "Verdade Compilada + Linha do Tempo": o `CLAUDE.md` guarda o que vale AGORA; este changelog guarda como chegamos aqui).
+
+Append-only, ordem reversa (mais recente no topo). Conteúdo movido verbatim — as **regras vivas** permaneceram no `CLAUDE.md`.
+
+---
+
+
+## 2026-04-29 — Refactor profundo em 5 waves (base reusável para outros segmentos)
+
+Pivô para tornar o curso-factory base de arquitetura para portais educacionais em **outros segmentos**, sem fork. As waves:
+
+1. **Auditoria** — mapa de bugs (4 subcomandos do CLI quebrados por imports inexistentes), código morto (`unified_finops.py`, `_build_writer_context`), duplicações de prompt e divergências entre CLAUDE.md e código real.
+2. **Fundação** — CLI reescrito (`validate`, `cost-report`, `batch`, `cache-clear` agora funcionam; `cmd_cost_report` lê o log real do `CostTracker` em vez da API fictícia que existia antes). `writer.py` e `reviewer.py` adotam `**template_vars` para paridade com os outros 3 agents.
+3. **Consolidação** — `unified_finops.py` removido (zero referências). `Cache` plugado no `LLMClient` (cache hit antes de circuit/retry). Defaults "Alexandre Caramaschi" / "Brasil GEO" removidos de `models.py:CourseDefinition` (`""` em vez de hardcode — quem instancia injeta via `ClientContext`). `SchemaBuilder` ganha clamp `max(30, duracao)`. Scripts ad-hoc movidos para `scripts/legacy/`.
+4. **Testes** — bateria expandida de **24 → 74 testes**: `test_cli` (11), `test_parsers` (14), `test_converters` (7), `test_cost_cache` (8), `test_validators_smoke` (10). Cobre todos os 8 subcomandos, parser canônico, conversor de drafts, FinOps, accent_checker, quality_gate e voice_guard. Toda chamada `datetime.utcnow()` migrada para `datetime.now(timezone.utc)`.
+5. **Docs** — `docs/ARCHITECTURE.md` reescrito como guia portal-agnóstico (camadas, o que é reusável, o que é segmento-específico, gaps conhecidos). Para novo portal: copiar `config/clients/_template/`, preencher YAML, eventualmente ajustar prompts.
+
+**Estado final:** 74/74 pytest verde, 8/8 subcomandos do CLI funcionais, zero código morto detectado, zero default de identidade no model.
+
+
+## 2026-04-25 — Base de conhecimento GEO/AEO/Agentic Commerce
+
+Foi adicionada uma camada doutrinária permanente em [docs/knowledge/geo-aeo/](docs/knowledge/geo-aeo/) que sintetiza 25+ papers acadêmicos (2025–2026) em 30 instruções operacionais, 7 princípios mestres, 4 checklists e tabela de thresholds quantitativos.
+
+**Quando usar.** Cursos sobre GEO, AEO, marketing por IA, comércio agêntico, MCP/A2A, RAG, knowledge graphs ou qualquer tema correlato devem usar este corpus como fonte primária. Cada agente do pipeline tem responsabilidades específicas:
+
+- **Pesquisa (Perplexity)** → fontes-âncora aceitas em `50-fontes-e-links.md`. Toda afirmação factual deve casar com pelo menos um paper deste catálogo.
+- **Redação (GPT-4o)** → princípios de `00-principios-mestres.md`, estrutura TL;DR/BLUF de `31-checklist-reescrita.md`, densidade de entidades 1/100 palavras (Instrução 17).
+- **Análise (Gemini)** → verificar os 16 pilares de `30-checklist-auditoria-geo16.md` em cada módulo.
+- **Classificação (Groq)** → tags com termos canônicos do `02-glossario.md`.
+- **Revisão (Claude)** → varredura final contra `01-anti-patterns.md`.
+
+**Princípio operacional.** Em conflito entre uma diretiva tática e um princípio mestre, **prevalece o princípio mestre**. A tese central: *GEO técnico é necessário, não suficiente. Estrutura validável vence prosa eloquente. Mídia conquistada explica a maior parte da variância de citação. Agent legibility é a nova SEO.*
+
+**Manutenção.** Revisão trimestral. Novos papers entram simultaneamente em `2X-papers-bloco-*.md`, `40-thresholds-quantitativos.md` e `50-fontes-e-links.md`.
+
+
+## 2026-04-19 — Refactor multi-tenant (Ondas 1-5)
+
+### Mudança estrutural: ClientContext
+- **Antes:** credencial Alexandre, domínio `alexandrecaramaschi.com`, padrão HSM/HBR/MIT Sloan e regras do voice guard estavam **hardcoded** em `models.py`, `voice_guard.py`, `pyproject.toml`, etc. Rodar a fábrica para outro cliente exigia fork.
+- **Depois:** tudo que varia por cliente vem de `config/clients/<id>/client.yaml`. O framework carrega o YAML em um `ClientContext` (`src/clients/context.py`) e injeta em CourseFactory, Orchestrator, SchemaBuilder, QualityGate e voice_guard_check.
+- **Cliente `default`** preserva 100% do comportamento pré-refactor (Brasil GEO). Qualquer `<id>` diferente escreve em `output/clients/<id>/`.
+- **CLI:** `python cli.py create "Curso" --client minhaempresa` ou `export CURSO_FACTORY_CLIENT=<id>`.
+- **Como listar:** `python cli.py clients`.
+- **Playbook completo:** [docs/MULTI-CLIENT.md](docs/MULTI-CLIENT.md).
+
+### Consolidação técnica
+- **Parser compartilhado** `src/parsers/markdown_parser.py`: fonte única de `slugify`, `extract_module_blocks`, `parse_module_to_sections`. Antes, `schema_builder.py` e `draft_to_course.py` tinham implementações paralelas divergentes.
+- **Providers em YAML** `config/providers.yaml` + `src/providers.py`: pricing, endpoints, default_model e fallback. `llm_client.py` só orquestra — mudança de preço/modelo é edição YAML.
+- **Voice Guard no QualityGate**: agora é a 4ª camada bloqueante. Score < `client.voice_guard.min_score` (padrão 70) ou erro crítico → `aprovado=False`.
+
+### Limpeza
+- `.gitignore` exclui `output/`, `*.egg-info/`, `.pytest_cache/`, `.mypy_cache/`.
+- `tests/fixtures/sample_course.json`: `nivel` corrigido de `intermediario` → `intermediário` (5/5 testes voltaram a verde).
+- `src/indexer/course_indexer.py`: removido hardcode `C:/Sandyboxclaude/...`; lê `LANDING_PAGE_DIR` do env ou derive de path relativo.
+
+### Commits da refatoração
+- `d3c1077` — refactor: multi-tenancy via ClientContext + limpeza de fundação
+- `203f126` — refactor: consolidação técnica (markdown_parser, providers.yaml, voice_guard em QualityGate)
+
+### Regra para trabalhos futuros
+Ao tocar em qualquer lógica sensível a autor/domínio/padrão editorial: passe pelo `ClientContext`, **não** hardcode. Se precisar de uma constante que varia por cliente, é campo de YAML.
+
+
+## 2026-04-09 — Mudanças da auditoria de ecossistema (Wave D)
+
+### NOVO: course_id propagado em cost_tracker (F32)
+- **Commit:** `72ee757` — `feat(cost-tracker): propaga course_id em todas chamadas LLM`
+- **Antes:** `cost_tracker.track()` sempre recebia `course_id=""`, tornando IMPOSSÍVEL responder "qual curso custou X" no `cost-report` ou aplicar budget guard granular por curso.
+- **Depois:** `LLMClient.set_course_context(course_id)` é chamado pelo `Orchestrator.run()` no início. Todas as chamadas LLM subsequentes propagam automaticamente.
+- **Como usar:** `python cli.py cost-report` agora pode agrupar por `course_id`. `cost_tracker.get_course_total('llm-finops')` retorna dados precisos por curso.
+- **Compat backward:** se `set_course_context` não for chamado, comportamento idêntico ao anterior.
+
+
+## 2026-04-09 — Mudanças da auditoria de ecossistema (Wave A-C)
+
+### 1. CLI `drafts-to-tsx` (F12)
+- **Commit:** `bc2f36e` — `feat(cli): drafts-to-tsx`
+- **Arquivos:** `cli.py` (+novo subcomando), `src/converters/__init__.py`, `src/converters/draft_to_course.py`
+- **Uso:** `python cli.py drafts-to-tsx [--input output/drafts] [--output output/converted_from_drafts]`
+- **Resultado da execução desta sessão:** **12/12 drafts órfãos convertidos** para TSX deployable. Output em `output/converted_from_drafts/` com `page.tsx` + `layout.tsx` válidos por curso.
+- **Próximo passo do owner:** revisar manualmente cada `output/converted_from_drafts/{slug}/page.tsx`, decidir quais publicar, mover aprovados para `output/deployed/`, commit final.
+- **Cursos liberados:** automacao-com-n8n (×2), deploy-moderno, geo-para-educacao-financeira-40 e -sub-18, llm-finops (×2), mcp-avancado (×2), prompt-engineering-avancado, seo-e-geo-para-advogados, seo-e-geo-para-revendedoras-de-joias.
+- **Conversor é best-effort:** parseia markdown da etapa `review` (preferida) ou `draft` (fallback), splita por headings, gera CourseSections (TEXT, CODE, TIP, CHECKPOINT). Cursos com 1 step só (sem headings claros) são clamped para 30 min mínimo.
+
+### 2. Pre-commit secret_guard (F44)
+- **Commit:** `8638b3f` — `sec(precommit): instala secret_guard`
+- **Arquivos:** `.tools/secret_guard.py`, `.githooks/pre-commit`
+- **Já ativado** localmente
+
+### Achados pendentes neste repo
+
+- **F13 (CRÍTICO):** ~~`voice_guard.py` programático ainda não existe.~~ **RESOLVIDO** na onda 2026-04-09 (B-012) e depois parametrizado por ClientContext em 2026-04-19.
+- **F38 → BAIXO:** `curso-factory` chama LLMs direto em vez de usar `geo-orchestrator`. Crosscheck Gemini concordou que esse achado estava superdimensionado. Migração para SDK fica para uma onda futura.

--- a/wiki/decisions/INDEX.md
+++ b/wiki/decisions/INDEX.md
@@ -1,0 +1,19 @@
+# Índice de decisões — curso-factory
+
+Uma linha por decisão (< ~200 caracteres). Este arquivo é o catálogo navegável; o
+detalhe vive no arquivo de cada decisão. Mantenha curto — ele entra no contexto.
+
+<!-- formato: - [Título curto](arquivo.md) — gancho de uma linha · `type` -->
+
+## Decisões (ADRs)
+
+- [ADR-001 — Adoção de LLM Wiki](ADR-001-adopcao-llm-wiki.md) — por que e como a base de conhecimento gerada por LLM · `decision`
+- [ADR-002 — Sync automático courses↔wiki](ADR-002-sync-automatico-courses-wiki.md) — pipeline de sincronização entre cursos e wiki · `decision`
+
+## Histórico
+
+- [CLAUDE-CHANGELOG](CLAUDE-CHANGELOG.md) — log datado de mudanças aplicadas, extraído do `CLAUDE.md` para mantê-lo enxuto
+
+---
+
+Como usar: ver [`README.md`](README.md). Template: [`_TEMPLATE.md`](_TEMPLATE.md).

--- a/wiki/decisions/README.md
+++ b/wiki/decisions/README.md
@@ -1,0 +1,48 @@
+# Memória de decisões — curso-factory
+
+Camada de memória persistente para o Claude Code, derivada do setup de "Memória
+Persistente para LLM": **os arquivos `.md` versionados são a fonte da verdade**; o
+índice é o que entra no contexto. Aqui moram decisões de arquitetura, erros-a-evitar
+e insights técnicos do projeto — um arquivo por decisão, auditável via `git diff`.
+
+Este diretório já abrigava os ADRs do projeto ([`ADR-001`](ADR-001-adopcao-llm-wiki.md),
+[`ADR-002`](ADR-002-sync-automatico-courses-wiki.md)); a camada abaixo apenas padroniza
+o formato e adiciona um índice navegável. Não substitui o `CLAUDE.md` (regras vivas).
+
+## Como funciona
+
+- **Fonte da verdade = arquivos.** Cada decisão (ou ADR) é um `.md` neste diretório.
+- **Índice enxuto.** [`INDEX.md`](INDEX.md) lista 1 linha por decisão (< ~200 caracteres).
+  O detalhe mora no arquivo, nunca no índice — linha longa incha o contexto.
+- **Formato de página** ([`_TEMPLATE.md`](_TEMPLATE.md)): **Verdade Compilada**
+  (topo, reescrito quando o entendimento muda) + **Linha do Tempo** (append-only,
+  nunca editada). O topo responde "o que vale AGORA?"; a linha do tempo, "como
+  chegamos aqui?". Os ADRs existentes seguem seu próprio formato — ambos convivem.
+
+## Tipos (frontmatter `type:`)
+
+- `decision` — escolha de arquitetura ou processo (decai devagar)
+- `mistake` — erro-a-evitar, com o sintoma e a correção (retido por mais tempo)
+- `insight` — descoberta técnica reaproveitável
+- `feedback` — preferência declarada pelo dono (não decai)
+
+## Três disciplinas (não pule nenhuma)
+
+1. **Dedup antes de gravar** — busque no `INDEX.md`/pasta; se já existe, ATUALIZE a
+   página (reescreva a Verdade Compilada, adicione 1 item na Linha do Tempo), não
+   crie outra. Senão o corpus vira duplicatas.
+2. **Cross-link na escrita** — toda decisão nova linka 2-3 relacionadas via
+   `[[nome-do-arquivo-sem-extensao]]`. Senão o conhecimento fica em ilhas.
+3. **Candidate-gate** — a captura automática (hook de fim de sessão) grava
+   rascunhos em `candidates/` (NÃO versionado, NÃO autoritativo). Promover =
+   destilar o aprendizado numa decisão real aqui e apagar o rascunho. Senão o
+   ruído de captura polui tudo (o modo de falha número 1 de sistemas auto-capturadores).
+
+## Manutenção (poda)
+
+Revise periodicamente: uma decisão obsoleta vai para `archive/` (não some — vira
+Linha do Tempo) com link para a sucessora. `mistake` e `feedback` raramente expiram;
+uma `decision` superada por outra é arquivada apontando para a nova.
+
+> Conceito e fluxo completos: `Setup-de-Memoria-Claude-Code.pdf` (máquina do dono,
+> em `C:/Sandyboxclaude/Melhorias/`).

--- a/wiki/decisions/_TEMPLATE.md
+++ b/wiki/decisions/_TEMPLATE.md
@@ -1,0 +1,18 @@
+---
+name: kebab-case-identificador
+description: "Uma frase — é o prompt de roteamento usado para achar esta decisão. Capriche aqui."
+metadata:
+  type: decision   # decision | mistake | insight | feedback
+  created: 2026-06-15
+---
+
+{Verdade Compilada — 3 a 10 linhas com o estado ACIONÁVEL atual. Esta seção é
+REESCRITA quando o entendimento muda, não acrescentada. Responde: "o que vale AGORA?".}
+
+Relacionadas: [[outra-decisao]], [[mais-uma]].
+
+---
+
+## Linha do tempo (append-only, ordem reversa)
+
+- **2026-06-15** — [criação] por que esta decisão nasceu (origem: sessão / PR / incidente)


### PR DESCRIPTION
Aplica o setup de **Memória Persistente para LLM** ao repo (arquivos `.md` versionados = fonte da verdade; índice enxuto entra no contexto). Mudança aditiva, sem tocar código de produto.

## O que muda
- **`wiki/decisions/`** — índice enxuto (`INDEX.md`), template (`_TEMPLATE.md`, formato *Verdade Compilada + Linha do Tempo*) e guia (`README.md`). Convive com os ADR-001/002 existentes.
- **`wiki/decisions/CLAUDE-CHANGELOG.md`** — histórico datado de **abril/2026** extraído do `CLAUDE.md` (refactors, base de conhecimento, auditorias). `CLAUDE.md`: **368 → 299 linhas**, mantendo as regras vivas e os blocos de maio/junho.
- **`.claude/`** — hook `Stop` de captura passiva (*candidate-gate*, não-bloqueante, falha em silêncio) + `settings.json`.
- **`CLAUDE.md`** — bloco de disciplina no topo (dedup / cross-link / candidate-gate).
- **`.gitignore`** — `candidates/` (rascunhos locais não-autoritativos) e estado local do Claude.

## Notas
- Sem mudanças em `src/`. O hook só grava rascunhos locais gitignored.
- Deriva de `Setup-de-Memoria-Claude-Code.pdf` e `pipeline-memoria-overnight.pdf`.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>