### PR TITLE
chore: governança Wave 3 — .gitattributes, smoke do CLI no CI e cobertura do secret_guard

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,24 @@
+# Normalização de EOL (issue #19) — repo desenvolvido em Windows + CI Linux.
+# Auto-detect: texto vs binário
+* text=auto eol=lf
+
+# Force LF para tudo que parser/tooling lê linha-a-linha
+*.py     text eol=lf
+*.yaml   text eol=lf
+*.yml    text eol=lf
+*.json   text eol=lf
+*.md     text eol=lf
+*.j2     text eol=lf
+*.toml   text eol=lf
+*.txt    text eol=lf
+
+# Shell scripts: LF obrigatório (rodam em container Linux do CI)
+*.sh     text eol=lf
+.githooks/* text eol=lf
+
+# Binários
+*.png    binary
+*.jpg    binary
+*.pdf    binary
+*.mp3    binary
+*.mp4    binary

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,39 @@ jobs:
               print(f'{cid}: OK ({c.author.name})')
           "
 
+      - name: CLI smoke (sem rede)
+        env:
+          OPENAI_API_KEY: "test-key-for-import-only"
+          ANTHROPIC_API_KEY: "test-key-for-import-only"
+          GOOGLE_API_KEY: "test-key-for-import-only"
+          GROQ_API_KEY: "test-key-for-import-only"
+          PERPLEXITY_API_KEY: "test-key-for-import-only"
+        run: |
+          python cli.py --help
+          python cli.py clients
+          python cli.py cost-report
+          python cli.py cache-clear
+          python cli.py emit-catalog --output-dir /tmp/catalog
+
       - name: Run pytest
         run: |
           pytest --tb=short -v
+
+      - name: Sentinela de bateria (>= 74 testes)
+        run: |
+          python - <<'EOF'
+          import re
+          import subprocess
+
+          out = subprocess.run(
+              ["pytest", "--collect-only", "-q"],
+              capture_output=True,
+              text=True,
+              check=False,
+          ).stdout
+          match = re.search(r"(\d+) tests? collected", out)
+          assert match, f"nao consegui ler a contagem de testes:\n{out[-500:]}"
+          total = int(match.group(1))
+          assert total >= 74, f"FAIL: bateria encolheu para {total} testes (minimo 74)"
+          print(f"OK: {total} testes coletados (minimo 74)")
+          EOF

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,23 @@ cp .env.example .env         # preencha as 5 chaves de API
 python -m pytest tests/ -v   # 74 testes verde
 ```
 
+### Ativando hooks locais (obrigatório)
+
+O repositório traz um hook de pre-commit (`.githooks/pre-commit`) que roda o
+`secret_guard` (`.tools/secret_guard.py`) e bloqueia commits contendo chaves de
+API, arquivos `.env` ou outros segredos. Ative uma única vez após o clone:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+Para conferir que está ativo, tente commitar um arquivo com uma chave falsa no
+formato real (por exemplo `sk-proj-` seguida de 40+ caracteres): o commit deve
+ser bloqueado com a mensagem `COMMIT BLOQUEADO`. O mesmo tipo de varredura roda
+server-side no CI via gitleaks (`security-scan.yml`), mas o hook local evita
+que o segredo chegue ao histórico remoto. Cobertura de regressão em
+`tests/test_secret_guard.py`.
+
 ## Princípios não negociáveis
 
 ### 1. Idioma

--- a/tests/test_secret_guard.py
+++ b/tests/test_secret_guard.py
@@ -1,0 +1,114 @@
+"""Testes do pre-commit secret_guard (.tools/secret_guard.py) — issue #17.
+
+As chaves falsas sao construidas em runtime por concatenacao para que este
+proprio arquivo nunca contenha um literal que casaria com os padroes de
+segredo (senao o gitleaks do CI e o proprio guard bloqueariam o commit).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+GUARD_PATH = PROJECT_ROOT / ".tools" / "secret_guard.py"
+
+
+def _load_guard():
+    spec = importlib.util.spec_from_file_location("secret_guard", GUARD_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+guard = _load_guard()
+
+# Chaves falsas montadas em runtime (nunca literais completos no source)
+FAKE_OPENAI_PROJ = "sk-" + "proj-" + "Ab1" * 20
+FAKE_ANTHROPIC = "sk-" + "ant-" + "api03-" + "Xy9" * 20
+FAKE_GOOGLE = "AIza" + "B" * 35
+FAKE_GITHUB_PAT = "ghp" + "_" + "C1d2" * 9
+FAKE_AWS = "AKIA" + "ABCDEFGHIJKLMNOP"
+
+
+class TestScanContent:
+    def test_detecta_chave_openai_project(self):
+        findings = guard.scan_content(f"OPENAI_API_KEY={FAKE_OPENAI_PROJ}")
+        assert findings, "chave sk-proj falsa deveria ser detectada"
+
+    def test_detecta_chave_anthropic(self):
+        findings = guard.scan_content(f"key = '{FAKE_ANTHROPIC}'")
+        assert findings
+
+    def test_detecta_chave_google(self):
+        findings = guard.scan_content(f"GOOGLE_API_KEY={FAKE_GOOGLE}")
+        assert findings
+
+    def test_detecta_github_pat(self):
+        findings = guard.scan_content(f"token: {FAKE_GITHUB_PAT}")
+        assert findings
+
+    def test_detecta_aws_access_key(self):
+        findings = guard.scan_content(f"aws_access_key_id = {FAKE_AWS}")
+        assert findings
+
+    def test_snippet_e_redacted(self):
+        findings = guard.scan_content(f"OPENAI_API_KEY={FAKE_OPENAI_PROJ}")
+        for _label, redacted, _context in findings:
+            assert FAKE_OPENAI_PROJ not in redacted, "segredo completo nao pode aparecer no log"
+
+    def test_placeholder_nao_dispara(self):
+        content = "ANTHROPIC_API_KEY=" + "sk-" + "ant-" + "api03-" + "X" * 54
+        findings = guard.scan_content(content)
+        assert findings == [], "placeholder uppercase do .env.example nao deveria disparar"
+
+    def test_conteudo_limpo_nao_dispara(self):
+        findings = guard.scan_content("def soma(a, b):\n    return a + b\n")
+        assert findings == []
+
+
+class TestEnvFileBlocked:
+    @pytest.mark.parametrize(
+        "filename",
+        [".env", ".env.local", ".env.production", "subdir/.env"],
+    )
+    def test_bloqueia_env(self, filename):
+        blocked, reason = guard.is_env_file_blocked(filename)
+        assert blocked, f"{filename} deveria ser bloqueado ({reason})"
+
+    @pytest.mark.parametrize(
+        "filename",
+        [".env.example", ".env.sample", ".env.template", "config/app.yaml"],
+    )
+    def test_permite_exemplos_e_arquivos_normais(self, filename):
+        blocked, _reason = guard.is_env_file_blocked(filename)
+        assert not blocked, f"{filename} nao deveria ser bloqueado"
+
+
+class TestCliFileMode:
+    """Integracao: invoca o guard como o hook faria, em modo --file."""
+
+    def _run(self, path: Path) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [sys.executable, str(GUARD_PATH), "--file", str(path)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_arquivo_com_segredo_retorna_1(self, tmp_path):
+        alvo = tmp_path / "config.py"
+        alvo.write_text(f'OPENAI_API_KEY = "{FAKE_OPENAI_PROJ}"\n', encoding="utf-8")
+        result = self._run(alvo)
+        assert result.returncode == 1
+        assert "SEGREDO DETECTADO" in result.stderr
+
+    def test_arquivo_limpo_retorna_0(self, tmp_path):
+        alvo = tmp_path / "app.py"
+        alvo.write_text("print('sem segredos aqui')\n", encoding="utf-8")
+        result = self._run(alvo)
+        assert result.returncode == 0


### PR DESCRIPTION
## O que este PR faz

Executa as três issues de governança já especificadas da auditoria (Wave 3):

### Issue #19 — `.gitattributes` para normalizar EOL
- Adiciona `.gitattributes` conforme especificado na issue (LF para texto/tooling, binários marcados).
- `git add --renormalize .` foi rodado e resultou em **no-op**: o índice já estava 100% LF (`git ls-files --eol`: 280 i/lf, 0 i/crlf). Ou seja, sem commit gigante de renormalização e sem risco para os PRs abertos.

### Issue #16 — `test.yml` refletindo a suíte real
- Novo step **CLI smoke (sem rede)**: `--help`, `clients`, `cost-report`, `cache-clear`, `emit-catalog --output-dir /tmp/catalog` — todos validados localmente offline (emit-catalog gerou catálogo com 15 cursos).
- Novo step **Sentinela de bateria**: falha se `pytest --collect-only` coletar menos de 74 testes (piso da issue; a suíte atual está bem acima).

### Issue #17 — documentar e validar o secret_guard
- `CONTRIBUTING.md`: nova seção "Ativando hooks locais" com `git config core.hooksPath .githooks`.
- `tests/test_secret_guard.py` (18 testes, verdes localmente): detecção de chaves OpenAI/Anthropic/Google/GitHub PAT/AWS, redação do snippet no log, allowlist de placeholders, bloqueio de `.env` (e liberação de `.env.example`), e integração do modo `--file` via subprocess. As chaves falsas são construídas em runtime por concatenação para não disparar o gitleaks do CI nem o próprio hook.
- A sub-task de nota na wiki (página Architecture) fica para a wave de wiki.

## Como validar
- CI verde (o próprio PR exercita os steps novos).
- `pytest tests/test_secret_guard.py -v`

Fecha #19. Fecha #16. Fecha #17 (exceto nota na wiki, tratada na wave de wiki).

🤖 Generated with [Claude Code](https://claude.com/claude-code)