### PR TITLE
docs(wiki): relação wiki/ x GitHub Wiki documentada (resolve drift da Wave 1)

### DIFF
--- a/wiki/README.md
+++ b/wiki/README.md
@@ -98,6 +98,27 @@ sub-comando `python cli.py wiki {sync, lint, query}` para reduzir
 fricção. Esta wave deixa scripts standalone para evitar conflito com
 trabalho em andamento na branch `feat/geo-seo-knowledge-2026-deep-research`.
 
+## Relação com a GitHub Wiki (definida em 08/07/2026)
+
+Este diretório `wiki/` e a GitHub Wiki do repositório
+(`curso-factory.wiki.git`) são superfícies distintas e **não se
+sincronizam**:
+
+- **`wiki/` (este diretório)**: base de conhecimento no padrão LLM Wiki
+  para consumo pelos agentes do pipeline. Governada por PR no `main`,
+  validada por `scripts/wiki/lint.py` e alimentada por
+  `scripts/wiki/sync-courses.py`. Nenhum script publica este conteúdo
+  na GitHub Wiki.
+- **GitHub Wiki**: documentação humana viva do projeto (arquitetura,
+  operação, referência, roadmap), editada por push direto na
+  `.wiki.git`. Regras e detalhes na página `_Convencoes` da própria
+  GitHub Wiki.
+
+A auditoria de 08/07/2026 apontava risco de drift entre as duas fontes;
+a resolução foi declarar os papéis acima em vez de sincronizar conteúdo
+disjunto por design. A branch histórica `wiki/karpathy-llm-wiki-pattern`
+foi verificada como totalmente contida no `main` e removida.
+
 ## Linhagem
 
 Vannevar Bush (Memex, 1945). Ted Nelson (Xanadu). Niklas Luhmann


### PR DESCRIPTION
## O que faz

Adiciona a seção "Relação com a GitHub Wiki" ao `wiki/README.md`, formalizando a decisão da Wave 4 (08/07/2026):

- O diretório `wiki/` no `main` é a base de conhecimento LLM Wiki (padrão Karpathy) para os agentes do pipeline, governada por PR e pelos scripts `scripts/wiki/lint.py` e `scripts/wiki/sync-courses.py`.
- A GitHub Wiki (`curso-factory.wiki.git`) é a documentação humana viva, editada por push direto; suas regras estão na página [_Convencoes](https://github.com/alexandrebrt14-sys/curso-factory/wiki/_Convencoes).
- Não há (nem deve haver) sincronização entre as duas: o conteúdo é disjunto por design. O "drift" apontado na auditoria era, na verdade, ausência de documentação dos papéis.

## Contexto

- GitHub Wiki atualizada em 08/07/2026: novas páginas `Atualizacoes-2026` e `_Convencoes`, nota do `secret_guard` na página Architecture (sub-task da issue #17), status na Home e inventário de testes anotado.
- Branch `wiki/karpathy-llm-wiki-pattern` verificada como totalmente contida no `main` (`git diff branch main --name-status` sem deleções) e removida.

🤖 Generated with [Claude Code](https://claude.com/claude-code)