### PR TITLE
feat(catalogo): curso agentic-operating-model (18 aulas) + drafts validados

### DIFF
--- a/config/courses.yaml
+++ b/config/courses.yaml
@@ -414,3 +414,26 @@ courses:
         descricao: "Zircônia Swarovski, Preciosa, nacional. Como identificar qualidade. Por que zircônia de qualidade eleva a percepção de valor da peça e justifica o preço."
       - titulo: "Coleções Herreira: filosofia, naming e storytelling"
         descricao: "Essência, Leveza, África, Celebrare, Valor do Tempo, Paty 4.4, Vitesse, Cápsula do Amor. Conceito por trás de cada coleção. Como usar o naming nas vendas sem soar decorado."
+
+  - slug: agentic-operating-model
+    nome: "O Novo Mundo de Fazer Software: do Agile ao Agentic Operating Model"
+    nivel: avançado
+    modulos: 18
+    descricao: "Como redesenhar o delivery para delegar, orquestrar, validar e governar trabalho feito por agentes de IA: Validation Engineering, Definition of Verified, TDD como controle de agente, evals, governança L0-L5 e métricas de board (Trust Velocity)."
+    tags: [agentic-coding, validation-engineering, tdd, governança-de-ia, model-routing, evals, sdd, métricas-board]
+    prerequisitos: [setup-claude-code]
+    duracao_estimada: "~360 min"
+    prioridade: P0
+    estrutura_modulos:
+      - titulo: "A Virada Agentic: da Assistência à Orquestração"
+        descricao: "A unidade de produção deixa de ser dev/hora e vira mudança verificada; Validation Engineering emerge como disciplina; vendors convergem para o humano operando um control plane de agentes."
+      - titulo: "Agentic Delivery: o Novo SDLC e a Orquestração por Camadas"
+        descricao: "O novo fluxo parte de intenção e critérios de sucesso, passa por um orquestrador que planeja e valida, e distribui execução por camadas de modelos — model routing como disciplina econômica."
+      - titulo: "Validation Engineering na Prática: Evidência em Vez de Afirmação"
+        descricao: "Quality Evidence Stack em dez camadas, Definition of Verified 2.0 com checklist executivo de 15 itens e Evidence Manifest."
+      - titulo: "Controle de Agentes: TDD, Revisão de Testes e Evals em Produção"
+        descricao: "TDD como mecanismo de controle de agente; testes gerados por IA exigem revisão (TDAD); evals, políticas e telemetria; Nightly Agentic Verification."
+      - titulo: "Humanos, Governança e Specs: o Sistema Nervoso do Operating Model"
+        descricao: "O humano muda de função; autonomia proporcional ao risco em seis níveis L0-L5 com guardrails; SDD e Spec Acceptance Pack."
+      - titulo: "O Operating Model Completo: Forecast, Métricas de Board, Tiny Teams e Cadência"
+        descricao: "Forecast probabilístico, painel AI-native com Trust Velocity, tiny teams com seis novos papéis, operating model em cinco camadas e cadência do daily ao quarterly."

--- a/output/drafts/agentic-operating-model/modulo-1.md
+++ b/output/drafts/agentic-operating-model/modulo-1.md
@@ -1,0 +1,165 @@
+# Módulo 1 — A Virada Agentic: da Assistência à Orquestração
+
+## Aula 1.1 — A virada de 2026: por que a unidade de produção deixou de ser dev/hora e virou mudança verificada
+Meta: id=`nova-unidade-de-producao` | duracao=`20 min` | icone=`workflow`
+Descrição: A tese executiva da era agentic: o debate saiu de "IA acelera o dev" para como a organização redesenha seu sistema operacional para delegar, orquestrar, validar e governar trabalho feito por agentes.
+
+### [text]
+A unidade de produção de software deixou de ser dev/hora, story point ou sprint capacity porque agentes de IA assumiram parte relevante da execução. A nova unidade é a **mudança verificada**: intenção clara, spec verificável, roteamento de modelos, execução agentic, evidência de validação, governança proporcional ao risco e custo por mudança verificada. Segundo a Gartner, até 2027 mais de 65% dos times que usam agentic coding tratarão IDEs como opcionais — controle e validação migram para plataformas automatizadas.
+
+No seu dia a dia, você provavelmente já sente o sintoma antes de nomear a causa. O relatório de sprint fecha com velocity estável, mas um único dev com agentes entrega em uma tarde o que o quadro estimou em duas semanas. As métricas que você reporta ao board descrevem esforço humano — e o esforço humano deixou de ser o fator limitante.
+
+O segundo semestre de 2026 marca essa virada. O debate deixou de ser "IA ajuda o desenvolvedor a codar mais rápido" e passou a ser como uma organização redesenha seu sistema operacional para delegar, orquestrar, validar e governar trabalho feito por agentes. Não é uma troca de ferramenta; é uma troca de unidade de medida.
+
+Os sete componentes da nova unidade de produção:
+
+-- **Intenção clara**: o problema, o outcome e as restrições, definidos por humanos.
+-- **Especificação verificável**: critérios de aceite que uma máquina ou um revisor consegue checar.
+-- **Roteamento de modelos**: a tarefa certa no modelo certo, pelo custo certo.
+-- **Execução agentic**: agentes implementam, humanos não digitam cada linha.
+-- **Evidência de validação**: provas anexadas à entrega, não afirmações.
+-- **Governança proporcional ao risco**: autonomia graduada conforme o blast radius.
+-- **Custo por mudança verificada**: a conta que substitui o custo por dev.
+
+> Na era agentic, velocidade sem prova é dívida.
+
+Essa é a frase-tese do curso, extraída do documento-fonte. Cada módulo a seguir operacionaliza um pedaço dela.
+
+### [text]
+A mudança não é especulativa e tem duas fontes de peso. A Gartner descreve a transição de **`AI-assisted development`** para **agentic software development** ao longo de todo o SDLC, com controle, governança e validação migrando para plataformas automatizadas (Gartner). A McKinsey & Company chega à mesma conclusão por outro ângulo: as empresas que capturam mais valor com IA em software não estão apenas comprando ferramentas — estão rearquitetando o delivery inteiro e reposicionando humanos como orquestradores, validadores de arquitetura e gestores de qualidade (McKinsey & Company).
+
+Compare o que suas métricas atuais medem com o que a nova gramática exige:
+
+| Métrica da era Agile | O que ela mede de fato | Substituta na era agentic |
+| --- | --- | --- |
+| Dev/hora | Presença e esforço humano | Custo por mudança verificada |
+| Story point | Estimativa de esforço humano | Risco de variação + custo de validação |
+| Sprint capacity | Quanto o time produz por ciclo | Quanto o sistema humano + agentes verifica por ciclo |
+| Velocity | Volume entregue | Trust Velocity: mudanças verificadas por tempo, custo e risco |
+
+A leitura executiva da tabela é desconfortável: nenhuma métrica da coluna esquerda distingue **mudança verificada** de código gerado. Um agente pode inflar todas elas sem produzir uma única entrega com prova. É por isso que a coluna direita não é cosmética — ela muda o que o board enxerga.
+
+Repare também no que o novo contexto adiciona à conversa que já existia. Scrum, Kanban, pontos, lead time, SDD e custo de tokens já estavam na mesa. A peça que faltava — e que este curso trata como espinha dorsal — é a **validação**.
+
+### [tip]
+Antes de redesenhar qualquer processo, faça o teste da tradução: pegue o último relatório que seu time enviou ao board e tente reescrever cada número como "mudanças verificadas". Se um número não sobrevive à tradução, ele mede esforço, não resultado. Esse exercício de 30 minutos costuma expor mais do que uma consultoria de três meses.
+
+### [text]
+Para diagnosticar sua organização, use três estágios de maturidade. No estágio **`AI-assisted`**, devs usam copilotos, mas o SDLC é o mesmo: PM escreve, dev implementa, QA testa. No estágio **agentic parcial**, agentes executam tarefas ponta a ponta em bolsões, sem governança formal nem evidência padronizada. No **Agentic Operating Model**, a organização opera as sete peças da nova unidade como sistema: specs verificáveis, roteamento, evidência e autonomia graduada.
+
+A honestidade do diagnóstico importa mais que o rótulo. A maioria das empresas que se declara "agentic" está no estágio parcial: tem agentes rodando, mas ninguém responde quem escreve specs, quem valida e quem governa autonomia. Essas três perguntas são o teste de estágio.
+
+> A pergunta que define seu estágio não é "quantos agentes você roda?" — é "quem prova que o que eles entregam funciona?".
+
+O restante do módulo ataca exatamente essa pergunta: a Aula 1.2 apresenta a disciplina que monta o pacote de provas, e a Aula 1.3 mostra por que todos os grandes vendors estão convergindo para o mesmo desenho.
+
+### [checkpoint]
+Verifique, como profissional, sua capacidade de aplicar a tese a um cenário real do seu contexto:
+
+-- **Exercício 1 — Auditoria da unidade de produção.** Liste as 3 métricas que seu time reporta hoje ao board (ex.: velocity, story points, deploys/semana) e reescreva cada uma na gramática da nova unidade de produção. Qual delas sobrevive como "mudança verificada" e qual é teatro?
+-- **Exercício 2 — Diagnóstico de virada.** Classifique sua organização em um dos três estágios (`AI-assisted`, agentic parcial, Agentic Operating Model), justificando com evidências concretas do último trimestre — quem escreve specs, quem valida, quem governa autonomia.
+
+## Aula 1.2 — Validation Engineering: a disciplina que responde "como saber se ficou melhor?"
+Meta: id=`validation-engineering-disciplina` | duracao=`20 min` | icone=`layers`
+Descrição: Não existe métrica objetiva universal que diga que o código "era nota 5 e virou 10" — o que existe é um pacote de evidências, e montar esse pacote virou disciplina estratégica.
+
+### [text]
+**Validation Engineering** é a disciplina que responde "como saber se ficou melhor?" sem depender de intuição: em vez de uma nota universal de qualidade, ela monta um pacote de evidências — testes automatizados, TDD, validação no browser, análise estática, load test, revisão de testes, spot check humano, evals, critérios de sucesso e observabilidade. É a disciplina estratégica do segundo semestre de 2026, porque separa "gerou código" de "entregou resultado verificável".
+
+O motivo de existir dessa disciplina são sete perguntas que o mundo agentic colocou na mesa e que os ritos do Agile não respondem:
+
+-- Como saber se ficou melhor?
+-- Como validar sem revisar tudo?
+-- Como usar TDD com agentes?
+-- Como testar agente em produção?
+-- Como medir drift e alucinação?
+-- Como operar um orquestrador de raciocínio premium (Ultracode)?
+-- Como separar "gerou código" de "entregou resultado verificável"?
+
+Perguntas intuitivas como "ficou melhor?" ou "o agente terminou?" são operacionalmente fracas: qualquer resposta é uma afirmação sem prova. Em um regime onde o agente produz um diff gigantesco em 45 minutos, afirmação sem prova é exatamente o que não escala.
+
+### [text]
+O insight mais maduro do documento-fonte merece citação direta:
+
+> "Não existe uma métrica objetiva universal que diga que o código era nota 5 e virou 10. O que existe é um pacote de evidências." — Alexandre Caramaschi, documento-fonte do curso
+
+Duas evidências externas sustentam por que isso virou pauta de gestão, não de tooling. O relatório DORA 2025 nomeia o **verification tax**: parte do tempo economizado na escrita de código é reempregado auditando, revisando e validando output de IA (DORA, 2025). E o Stack Overflow Survey 2025 mostra que 46% dos desenvolvedores desconfiam ativamente da precisão de ferramentas de IA, contra 33% que confiam — e os mais experientes são os mais céticos (Stack Overflow, 2025).
+
+A leitura combinada é direta: a geração ficou barata, a confiança ficou cara. Quem trata validação como etapa final de QA paga o verification tax de forma desorganizada. Quem trata validação como disciplina — com dono, instrumentos e rito — converte o mesmo custo em ativo de velocidade.
+
+### [warning]
+O anti-padrão mais caro da era agentic é aceitar "done" sem evidência. Ele troca a falsa confiança humana ("revisei por cima, parece bom") pela falsa confiança automatizada ("o agente disse que terminou e os testes dele passaram"). Se a sua definição de pronto não exige prova anexada, você não tem Validation Engineering — tem esperança com CI.
+
+### [text]
+O pacote de evidências tem dez componentes, e cada um prova uma coisa diferente. Confundi-los é a origem de a maioria das discussões improdutivas sobre "qualidade":
+
+| Componente | O que ele prova |
+| --- | --- |
+| Testes automatizados | O comportamento esperado se mantém executável e checável |
+| TDD | O critério de sucesso existia antes da implementação |
+| Validação no browser | O fluxo real do usuário completa de ponta a ponta |
+| Análise estática | Contratos, tipos e padrões são respeitados |
+| Load test | O sistema performa sob carga, com análise estatística |
+| Revisão de testes | Os testes fazem sentido — não confirmam a solução errada |
+| Spot check humano | Julgamento contextual em pontos de maior risco |
+| Evals para agentes | O agente se comporta como esperado, não só o código |
+| Critérios de sucesso | A entrega é aderente à intenção declarada |
+| Loops de validação + observabilidade | O comportamento em produção é medido, não presumido |
+
+Montar e operar esse pacote é trabalho de engenharia — por isso o nome. A disciplina se materializa ao longo do curso: o **Quality Evidence Stack** detalha as camadas no Módulo 3, TDD e evals viram mecanismos de controle no Módulo 4, e a governança fecha o ciclo no Módulo 5. O papel formal de Validation Engineer aparece no Módulo 6.
+
+A decisão executiva desta aula é uma só: Validation Engineering precisa de dono e de rito no seu time. Sem dono, o pacote de evidências vira checklist morto; sem rito, vira burocracia que o próximo deadline atropela.
+
+### [checkpoint]
+Aplicação prática da disciplina no seu pipeline atual:
+
+-- **Exercício 3 — Inventário de evidências.** Pegue o último PR relevante gerado com IA no seu time e liste quais dos dez componentes do pacote de evidências existiam de fato. Atribua um score de completude (0 a 10) e identifique as duas lacunas de maior risco.
+-- **Exercício 4 — Desenho de papel.** Escreva a job description de 1 parágrafo para a capacidade "Validation Engineer" no seu contexto — o que essa pessoa (ou agente) constrói, o que ela veta e a quem responde. O papel formal será detalhado no Módulo 6; aqui, o objetivo é confrontar o desenho com a sua estrutura real.
+
+## Aula 1.3 — De chatbot a control plane: a convergência de Anthropic, OpenAI, Google, GitHub e Microsoft
+Meta: id=`convergencia-vendors-control-plane` | duracao=`20 min` | icone=`scale`
+Descrição: O movimento não é de um vendor: todos os grandes ecossistemas convergem para agentes que planejam, executam, revisam PRs e validam — e o stack empresarial se desloca de features para outcomes.
+
+### [text]
+Anthropic, OpenAI, Google, GitHub e Microsoft convergem para o mesmo padrão: agentes que planejam, executam, revisam PRs e validam trabalho, operados por humanos a partir de um **control plane** — não de um chat. A Gartner projeta que, até o fim de 2026, 40% das aplicações corporativas estarão integradas com agentes de IA task-specific, contra menos de 5% hoje. O futuro próximo não é um dev usando um chatbot; é um humano operando um plano de controle de agentes.
+
+O movimento extrapola a engenharia de software. A integração de agentes task-specific desloca o stack empresarial para workflows dinâmicos e orquestração entre agentes (Gartner). Isso significa que a mesma virada que atinge seu time de produto atinge seus fornecedores — e seus contratos.
+
+A ameaça econômica tem nome: **agentic arbitrage**. A Gartner estima que até US$ 234 bilhões em gastos corporativos com SaaS de aplicações empresariais ficarão expostos a esse fenômeno até 2030, porque agentes poderão executar tarefas end-to-end através de múltiplos sistemas, deslocando valor de features, telas e dashboards para **outcomes** (Gartner).
+
+> Quando um agente atravessa três sistemas para executar o outcome, o valor deixa de estar nas telas desses sistemas — e passa a estar em quem orquestra e verifica a travessia.
+
+### [text]
+Em engenharia, a convergência dos cinco grandes ecossistemas é visível na direção estratégica de cada um:
+
+| Ecossistema | Direção estratégica |
+| --- | --- |
+| Anthropic / Claude Code | Workflows dinâmicos, ultracode, subagentes, hooks, code review agentic |
+| OpenAI / Codex | Delegação de tarefas como "coworker", integração com Slack, SDK, revisão automática de PRs |
+| Google / Gemini CLI | Agente em GitHub Actions: triagem de issues, revisão de PRs, testes, correção de bugs, com least privilege e allowlisting de comandos |
+| GitHub / Spec Kit | Especificação como artefato vivo e executável |
+| Microsoft / SDD | Requisitos, planos, tarefas e validação integrados ao ciclo spec-first |
+
+Três detalhes dessa tabela merecem atenção executiva. A Anthropic descreve **dynamic workflows** como a capacidade de o Claude escrever scripts de orquestração, rodar dezenas ou centenas de subagentes em paralelo e verificar o trabalho antes de consolidar resultados (Anthropic, documentação do Claude). A verificação antes da consolidação é o padrão que a Aula 1.2 nomeou como disciplina.
+
+A OpenAI afirma que o Codex evoluiu para delegação de tarefas como um "coworker", com uso interno massivo e aumento de PRs por semana (OpenAI). O sinal relevante não é o volume — é que a própria vendor mede a si mesma em PRs delegados, não em sugestões aceitas no editor.
+
+O Google posiciona o Gemini CLI em GitHub Actions como colaborador autônomo sob controles explícitos: **least privilege** e **allowlisting** de comandos (Google). Governança nasce embutida no produto, não como camada posterior — antecipação direta do Módulo 5.
+
+### [tip]
+Não tente adotar as cinco direções de uma vez. Escolha a capacidade mais próxima do seu gargalo atual — para a maioria dos times, é a revisão agentic de PRs — e implante com allowlisting desde o primeiro dia. Uma capacidade operando com governança ensina mais sobre o seu estágio de maturidade do que cinco pilotos sem controle.
+
+### [text]
+A conclusão da convergência fecha a tese do módulo:
+
+> O futuro próximo não é um dev usando um chatbot. É um humano operando um control plane de agentes.
+
+Para o executivo, isso gera duas agendas imediatas. A primeira é defensiva: revisar a carteira de SaaS sob a lente do agentic arbitrage, perguntando contrato a contrato se o outcome pode ser executado por um agente atravessando sistemas. A segunda é ofensiva: mapear quais capacidades de control plane — subagentes, hooks, revisão agentic de PRs, allowlisting — sua organização já opera e quais ainda dependem de processo manual.
+
+Esse mapa de gaps é o insumo do Módulo 2, que desenha o novo SDLC: como a intenção vira plano, como o orquestrador decompõe o trabalho e como o roteamento de modelos vira disciplina econômica. A infraestrutura conceitual — nova unidade de produção, Validation Engineering e control plane — está posta.
+
+### [checkpoint]
+Transforme a convergência em decisão de portfólio:
+
+-- **Exercício 5 — Mapa de exposição.** Para os 3 maiores contratos SaaS da sua empresa, avalie se há risco de agentic arbitrage (o outcome pode ser executado por um agente atravessando sistemas?) e classifique cada um em manter, renegociar ou substituir por agente. Justifique com o critério de valor: feature ou outcome?
+-- **Exercício 6 — Gap de control plane.** Compare seu setup atual com a tabela de vendors — quais capacidades (subagentes, hooks, PR review agentic, allowlisting) você já opera e quais ainda dependem de processo manual? Priorize o fechamento de 1 gap para os próximos 30 dias.

--- a/output/drafts/agentic-operating-model/modulo-2.md
+++ b/output/drafts/agentic-operating-model/modulo-2.md
@@ -1,0 +1,146 @@
+# Módulo 2 — Agentic Delivery: o Novo SDLC e a Orquestração por Camadas
+
+## Aula 2.1 — O novo SDLC: de software delivery para Agentic Delivery
+Meta: id=`do-sdlc-ao-agentic-delivery` | duracao=`20 min` | icone=`workflow`
+Descrição: Lado a lado, o velho modelo (demanda, estimativa, implementação, QA, review, deploy) e o novo (intenção, orquestração, execução multi-modelo, crítica adversarial, revisão por risco, evidência anexada, forecast por regime).
+
+### [text]
+**Agentic Delivery** é o ciclo de vida de software redesenhado para trabalho executado por agentes de IA: parte de intenção e critérios de sucesso, passa por um orquestrador que planeja, decompõe e valida, e distribui a execução entre camadas de modelos e ferramentas determinísticas. Segundo o Gartner, até 2027 mais de 65% dos times que usam agentic coding tratarão IDEs como opcionais — controle, governança e validação migram para plataformas automatizadas.
+
+Antes de redesenhar o fluxo, vale nomear o que ele substitui. O modelo tradicional de delivery opera em sete passos que, como profissional de engenharia, você provavelmente já executou de memória no seu dia a dia:
+
+-- O PM escreve a demanda no backlog.
+-- O time estima em pontos ou horas.
+-- O dev implementa.
+-- O QA testa.
+-- O code review valida linha a linha.
+-- O DevOps sobe para produção.
+-- As métricas aparecem depois, se aparecerem.
+
+Esse desenho já vinha sendo pressionado por Agile e DevOps havia duas décadas. Com agentes, ele se torna estruturalmente insuficiente: o Gartner descreve a transição de **`AI-assisted development`** para **agentic software development** ao longo de todo o SDLC — e um pipeline desenhado para humanos digitando código não tem onde encaixar um agente que produz um diff de milhares de linhas em minutos.
+
+> O gargalo deixou de ser escrever código. O gargalo passou a ser provar que o código escrito por agentes está correto, seguro e aderente à intenção.
+
+### [text]
+O novo modelo tem oito passos, e a diferença central não é a automação — é onde nascem os critérios de sucesso e onde a prova é anexada:
+
+-- O humano define **intenção**, restrições e critérios de sucesso mensuráveis.
+-- O **orquestrador** cria o plano e o workflow de validação.
+-- Modelos diferentes executam partes diferentes do trabalho (model routing, detalhado na Aula 2.3).
+-- Ferramentas determinísticas validam: build, lint, typecheck, testes.
+-- Agentes revisores fazem **crítica adversarial** sobre o output.
+-- Humanos revisam por risco, não por volume.
+-- As evidências são anexadas ao PR — não afirmadas em stand-up.
+-- O forecast é recalibrado por regime de trabalho, não por histórico bruto.
+
+Repare na inversão de sequência. No velho modelo, a validação era uma fase (QA) posicionada depois da implementação; no novo, o workflow de validação é criado no passo dois, antes de qualquer código existir. A McKinsey observa o mesmo padrão nas empresas que mais capturam valor com IA: elas não compram ferramenta — rearquitetam o delivery inteiro e reposicionam humanos como orquestradores, validadores de arquitetura e gestores de qualidade.
+
+Dois passos merecem atenção executiva porque são os que quase nunca existem hoje. A crítica adversarial — um agente revisor tentando quebrar o trabalho de outro — e a evidência anexada ao PR reaparecem no Quality Evidence Stack (Módulo 3) e no papel do humano como auditor de risco (Módulo 5). São a peça que separa Agentic Delivery de simplesmente "usar IA mais rápido".
+
+### [text]
+A mudança de paradigma completa, tal como o documento-fonte a sistematiza, cabe em dez pares antes/depois:
+
+| Antes (software delivery) | Depois (Agentic Delivery) |
+|---|---|
+| Backlog item | Spec executável |
+| Story point | Risco de variação + custo de validação |
+| Dev como executor | Dev como orquestrador |
+| IA como copiloto | IA como força de trabalho agentic |
+| Code review manual | Revisão multiagente + humana por risco |
+| CI/CD | Trust pipeline |
+| Definition of Done | **Definition of Verified** |
+| Velocity | **Trust Velocity** |
+| Custo por dev | Custo por mudança verificada |
+| Squad como capacidade de execução | Squad como ownership, contexto e governança |
+
+Cada linha é uma decisão de redesenho, não uma troca de vocabulário. Um backlog item vira **spec executável** quando carrega intenção, restrições e critérios verificáveis que um agente consegue executar sem ambiguidade. O story point deixa de medir esforço humano de digitação e passa a precificar **risco de variação + custo de validação** — a estimativa relevante quando o código nasce em minutos. E o CI/CD vira **trust pipeline** quando deixa de apenas compilar e passa a produzir o pacote de provas que sustenta o merge.
+
+A linha mais cara de ignorar é a da revisão. Segundo o Stack Overflow Survey 2025, 46% dos desenvolvedores desconfiam ativamente da precisão de ferramentas de IA, contra 33% que confiam — e os mais experientes são os mais céticos. Revisar por risco, não por volume, é a única forma de honrar esse ceticismo sem afogar os seniores em diffs gigantescos.
+
+### [tip]
+Comece a migração pelo vocabulário dos artefatos, não pela ferramenta. Reescreva os próximos cinco itens do backlog com três campos obrigatórios: intenção, restrições e critérios de sucesso mensuráveis. Se um agente "literal-minded" não conseguiria executar o item sem perguntar nada, ele ainda é backlog item — não é spec executável. É um teste que você pode aplicar imediatamente: custa uma tarde e revela mais sobre a maturidade do time do que qualquer avaliação de ferramenta.
+
+### [checkpoint]
+-- **Exercício 1 — Re-desenho de fluxo.** Pegue a última feature relevante entregue pelo seu time e reconte a história dela seguindo os oito passos do Agentic Delivery. Marque em vermelho cada passo que hoje não existe ou é informal — tipicamente a crítica adversarial e a evidência anexada ao PR. Apresente o resultado ao tech lead e priorize um passo para formalizar neste trimestre.
+-- **Exercício 2 — Tradução de vocabulário.** Reescreva 5 itens do seu backlog atual como specs executáveis, com intenção, restrições e critérios de sucesso mensuráveis. Compare o tempo de escrita com o tempo que o time gastaria esclarecendo ambiguidades no meio do sprint.
+-- **Exercício 3 — Análise da tabela.** Dos dez pares antes/depois, avalie se a sua organização já opera cada linha: classifique em "já operamos assim", "em transição" ou "nem começamos" — e justifique com um exemplo concreto do último mês.
+
+## Aula 2.2 — Ultracode não é modo mágico: é camada de planejamento, decomposição, verificação e auditoria
+Meta: id=`ultracode-orquestrador-nao-modo-magico` | duracao=`20 min` | icone=`layers`
+Descrição: O modo de raciocínio premium deve ser tratado como board member técnico da execução — não como estagiário caro fazendo batch job — e a pergunta certa não é "uso ou não", mas "qual etapa merece raciocínio premium".
+
+### [text]
+**Ultracode** — o modo de raciocínio premium — não é um botão que melhora qualquer tarefa: é uma camada de planejamento, decomposição, verificação e auditoria. Se o modelo cria sozinho o workflow de validação, ele opera como orquestrador, não como mais um gerador de código. A documentação da Anthropic adverte que **dynamic workflows** consomem significativamente mais recursos, e a recomendação explícita é começar com escopos menores antes de escalar.
+
+O ponto de partida analítico é observar o que o modo premium efetivamente produz quando bem usado: plano, decomposição em subtarefas, mapa de riscos, critérios de validação e revisão adversarial do trabalho executado. Nenhum desses artefatos é código de feature. São artefatos de **orquestração** — o mesmo tipo de output que se espera de um staff engineer desenhando uma execução, não de alguém digitando a execução.
+
+Na prática dos dynamic workflows descritos pela Anthropic, o padrão é concreto: o modelo escreve scripts de orquestração, dispara dezenas ou centenas de **subagentes** em paralelo e verifica o trabalho antes de consolidar. O raciocínio premium fica no topo da pirâmide, decidindo e auditando; o volume de execução desce para camadas mais baratas.
+
+> "Modelo premium deve ser usado como board member técnico da execução, não como estagiário caro fazendo batch job." — Alexandre Caramaschi
+
+### [warning]
+A pegadinha executiva está no custo composto. Dynamic workflows consomem significativamente mais tokens e recursos do que o uso convencional — a própria Anthropic recomenda validar em escopos menores antes de escalar. O anti-padrão clássico é o time descobrir o modo premium, ligá-lo para tudo e apresentar ao CFO uma fatura que triplicou sem nenhuma métrica de mudança verificada para justificá-la. Escalar orquestração sem governança de custo é a versão financeira do débito técnico: invisível no demo, dolorosa no fechamento do mês.
+
+### [text]
+A maturidade chega quando a pergunta muda. "Uso Ultracode ou não?" é uma pergunta binária sobre ferramenta; a pergunta correta é: **qual etapa do fluxo merece raciocínio premium, e qual pode ser executada por modelos mais baratos ou por ferramentas determinísticas?**
+
+Essa troca reorganiza o pipeline inteiro em torno de uma alocação, não de uma adesão:
+
+-- Decisão de arquitetura, decomposição de problema ambíguo, revisão adversarial de mudança crítica: candidatas legítimas a raciocínio premium.
+-- Refactor mecânico, geração de testes a partir de spec clara, pesquisa no repositório, documentação: trabalho de modelos intermediários ou eficientes.
+-- Build, lint, typecheck, execução de testes: ferramentas determinísticas, custo marginal próximo de zero e resultado binário.
+
+O critério de corte é o valor do julgamento na etapa. Onde um erro de decisão contamina todo o trabalho a jusante — o plano errado gera cem subagentes executando a coisa errada — o raciocínio premium se paga. Onde a tarefa é repetível e verificável por teste, pagar preço de board member por trabalho de batch job é desperdício puro.
+
+O custo, aliás, é variável de projeto, não rodapé de fatura. Há diferenças materiais de preço entre modelos como Fable, Opus, Sonnet e Haiku, e alavancas como prompt caching e o runtime de agentes alteram a conta de forma significativa — tema da próxima aula, onde essa alocação vira topologia formal de cinco camadas.
+
+### [tip]
+Institua a regra do "um ponto premium por entrega": ao planejar qualquer entrega relevante, o time declara antecipadamente qual único ponto do workflow exige raciocínio premium — em geral o plano inicial ou a revisão adversarial final. Se alguém quiser um segundo ponto, precisa justificar por risco, não por conveniência. A regra força a conversa de alocação antes do gasto e cria o hábito que a métrica Model Mix Efficiency (Módulo 6) vai medir depois.
+
+### [checkpoint]
+-- **Exercício 4 — Auditoria de desperdício premium.** Liste os últimos 5 usos de modelo de raciocínio elevado no seu fluxo e classifique cada um como decisão/arquitetura (uso correto) ou tarefa repetível (desperdício). Estime o custo evitável em reais por mês se os usos incorretos descessem uma camada.
+-- **Exercício 5 — Desenho de workflow.** Para um problema real do próximo sprint, escreva o workflow que o orquestrador deveria criar — decomposição em subtarefas, subagentes envolvidos, pontos de verificação — e marque o único ponto que exige raciocínio premium. Defenda a escolha diante do tech lead.
+-- **Exercício 6 — Justificativa executiva.** Redija o parágrafo que você usaria para explicar ao seu CFO por que o gasto com o modo premium deve subir na etapa de planejamento e cair na etapa de execução — usando a lógica de board member versus estagiário caro.
+
+## Aula 2.3 — Model routing como disciplina econômica: a topologia de cinco camadas de execução
+Meta: id=`model-routing-topologia-cinco-camadas` | duracao=`20 min` | icone=`scale`
+Descrição: Premium define plano e revisão adversarial; intermediários executam refactors; eficientes fazem tarefas repetíveis; ferramentas determinísticas validam; o humano sênior arbitra riscos e trade-offs.
+
+### [text]
+**Model routing** é a disciplina de colocar o modelo certo, na etapa certa, com a permissão certa, pelo custo certo. A topologia recomendada tem cinco camadas: premium define plano e revisão adversarial; intermediários executam refactors; eficientes fazem tarefas repetíveis; ferramentas determinísticas validam; o humano sênior arbitra riscos e trade-offs. Como a documentação de preços da Anthropic mostra diferenças materiais de custo entre modelos como Fable, Opus, Sonnet e Haiku, o roteamento é decisão econômica, não apenas técnica.
+
+A analogia útil vem da própria gestão. Nenhum CTO aloca o arquiteto mais caro da empresa para renomear variáveis, nem delega a decisão de migração de banco ao estagiário — e ninguém chama isso de "política de RH": chama-se alocação de capacidade por valor. Com modelos de IA, a mesma lógica ganha precisão de tabela de preços, porque cada camada tem custo por token conhecido e publicado.
+
+O erro comum é tratar o roteamento como preferência individual do dev ("eu gosto de usar o modelo X"). Em Agentic Delivery, o roteamento é política de engenharia: uma matriz explícita de tipo de tarefa por camada de execução, com dono, revisão periódica e uma métrica de board que a audita — **Model Mix Efficiency**, apresentada no Módulo 6.
+
+### [text]
+A topologia de cinco camadas, conforme o documento-fonte a recomenda:
+
+| Camada | Quem executa | Responsabilidade |
+|---|---|---|
+| 1. Premium / Ultracode | Modelo de raciocínio elevado | Plano, riscos, critérios de validação, decomposição, revisão adversarial |
+| 2. Intermediária | Modelos de capacidade média | Refactors, sínteses, mudanças complexas de código |
+| 3. Eficiente | Modelos rápidos e baratos | Pesquisa no repo, alterações repetíveis, geração de testes, documentação |
+| 4. Determinística | Ferramentas clássicas | Build, lint, typecheck, tests, SAST, dependency scan, load test |
+| 5. Humano sênior | Tech lead / staff / CTO | Riscos, arquitetura, segurança, produto, testes, trade-offs |
+
+Duas leituras estruturais importam. Primeira: a camada 4 não é opcional nem "menos nobre" — ferramentas determinísticas produzem veredito binário a custo marginal quase nulo, e tudo que puder ser verificado por elas não deveria consumir token de modelo algum. Segunda: o humano sênior é uma camada de execução do pipeline, com responsabilidade definida — arbitrar o que nenhuma automação arbitra —, não um supervisor externo olhando por cima do ombro.
+
+O fluxo típico de um PR atravessa as camadas em forma de ampulheta: nasce na camada 1 (plano e decomposição), engorda nas camadas 2 e 3 (execução paralela), é espremido pela camada 4 (validação determinística) e volta a subir — revisão adversarial na camada 1, arbitragem de risco na camada 5. O contexto dessa disciplina é o mercado que o Módulo 1 descreveu. Segundo o Gartner, até o fim de 2026 40% das aplicações corporativas estarão integradas com agentes task-specific, contra menos de 5% hoje — e a mesma consultoria estima até US$ 234 bilhões em gastos com SaaS expostos ao agentic arbitrage (Gartner, projeção para 2030). Quem orquestra em cinco camadas opera essa escala; quem usa um modelo único para tudo paga por ela.
+
+### [tip]
+Antes de otimizar o roteamento, capture as duas alavancas de custo que independem dele: prompt caching e o runtime de agentes. Cachear o contexto estável (spec, convenções do repo, instruções de sistema) reduz o custo de cada chamada subsequente, e o runtime determina quantas chamadas uma tarefa consome de fato. Um roteamento perfeito sobre prompts sem cache pode custar mais do que um roteamento mediano com caching bem configurado — meça as duas coisas juntas.
+
+### [text]
+A regra de ouro do operating model, antecipando a conclusão do curso: **o modelo certo, na etapa certa, com a permissão certa, pelo custo certo**. Cada um dos quatro termos é um eixo de governança — capacidade, posição no fluxo, autonomia concedida e unit economics — e a topologia de cinco camadas é a forma operacional de cumprir os quatro ao mesmo tempo.
+
+> "Usar modelo premium para tudo é desperdício. Usar modelo barato para decisão crítica é risco." — documento-fonte, conclusão 20.6
+
+Os dois erros são simétricos e igualmente caros. O primeiro aparece na fatura: paga-se preço de raciocínio elevado por triagem de issue e geração de boilerplate. O segundo aparece no incidente: uma decisão de arquitetura ou uma mudança de alto blast radius delegada a um modelo eficiente, sem revisão adversarial nem arbitragem humana, cujo custo só se revela em produção.
+
+A disciplina fecha o ciclo com medição. **Cost per Verified Change** — o custo por mudança verificada, componente da nova unidade de produção do Módulo 1 — só é gerenciável quando o roteamento é política explícita; e a Model Mix Efficiency, no painel de board do Módulo 6, mede exatamente se cada classe de tarefa está rodando na camada certa. Sem matriz de roteamento, essas métricas não têm o que medir: há apenas gasto agregado e intuição.
+
+### [checkpoint]
+-- **Exercício 7 — Matriz de roteamento.** Construa a tabela tarefa × camada para as 10 tarefas mais frequentes do seu time (triagem de issue, geração de teste, refactor, migration, revisão adversarial, documentação, pesquisa no repo, entre outras) e valide com o tech lead onde a matriz diverge da prática atual. Cada divergência é desperdício ou risco — classifique qual.
+-- **Exercício 8 — Simulação de unit economics.** Para um PR típico, estime o custo do fluxo "tudo premium" versus o fluxo roteado pela topologia de cinco camadas, usando a tabela de preços pública dos modelos que seu time usa. Calcule a economia percentual e descreva o risco que o roteamento introduz (e como a camada 5 o mitiga).
+-- **Exercício 9 — Projeto de política.** Redija a política de roteamento de uma página para o seu time — camadas, tipos de tarefa por camada, exceções permitidas, dono da matriz e cadência de revisão — e defina como a aderência será auditada quando a Model Mix Efficiency entrar no painel.

--- a/output/drafts/agentic-operating-model/modulo-3.md
+++ b/output/drafts/agentic-operating-model/modulo-3.md
@@ -1,0 +1,160 @@
+# Módulo 3 — Validation Engineering na Prática: Evidência em Vez de Afirmação
+
+## Aula 3.1 — 'Ficou melhor?' é a pergunta errada: peça evidências, não afirmações
+Meta: id=`ficou-melhor-pergunta-errada` | duracao=`20 min` | icone=`scale`
+Descrição: A pergunta operacionalmente correta é: que evidências mostram que o comportamento foi preservado ou melhorado, que o risco caiu e que o custo futuro de mudança diminuiu?
+
+### [text]
+Em entregas feitas por agentes de IA, a pergunta operacional não é "ficou melhor?", e sim: que evidências mostram que o comportamento esperado foi preservado ou melhorado, que o risco caiu e que o custo futuro de mudança diminuiu? Não existe nota universal de código — existe uma cesta de evidências. A regra da Anthropic para o Claude Code resume o novo standard: peça evidências, não afirmações; se não dá para verificar, não deveria ir para produção.
+
+Se você já acompanhou uma entrega de agente no seu dia a dia, provavelmente já viveu essa cena: o refactor termina, alguém pergunta "ficou melhor?", e a resposta é um "sim" confiante — sem prova. A pergunta é intuitiva, mas operacionalmente fraca, porque convida a uma opinião em vez de exigir um fato verificável. Com um dev humano, a experiência do revisor compensava parte dessa fraqueza; com um agente que produz um diff gigantesco em minutos, ela vira um buraco de risco.
+
+O problema estrutural é que "melhor" não tem métrica objetiva universal. Não existe instrumento que diga que o código "era nota 5 e virou 10". O que existe — e o que uma organização madura passa a exigir — é a **reformulação da pergunta** em três dimensões verificáveis:
+
+-- **Comportamento**: que evidências mostram que o comportamento esperado foi preservado ou melhorado?
+-- **Risco**: que evidências mostram que o risco caiu — segurança, regressão, blast radius?
+-- **Custo futuro de mudança**: que evidências mostram que a estrutura ficou mais simples de evoluir?
+
+> "Na era agentic, velocidade sem prova é dívida." — Alexandre Caramaschi
+
+Essa é a tese que atravessa todo o curso, aplicada aqui à dimensão de qualidade. Um agente que entrega rápido sem evidência não está adiantando o trabalho: está transferindo o custo da verificação para o futuro, com juros.
+
+### [text]
+A documentação de boas práticas do Claude Code (Anthropic) formula a regra com precisão cirúrgica: **"peça evidências, não afirmações"**. Evidência pode ser saída de teste, comando executado, screenshot ou log — artefatos que qualquer revisor consegue inspecionar sem confiar na palavra de quem (ou do que) entregou. E a regra forte que completa o standard: se não dá para verificar, não deveria ir para produção.
+
+A tradução prática dessa regra é um dicionário de conversão. Toda afirmação de entrega tem uma evidência correspondente que a converte em fato:
+
+| Afirmação (fraca) | Evidência (verificável) |
+|---|---|
+| "Funciona" | Saída dos testes unitários e de integração passando |
+| "Não quebrou nada" | Suíte de regressão executada, com resultado anexado |
+| "Ficou mais rápido" | Load test com comparação estatística antes/depois |
+| "A tela está correta" | Screenshot ou browser validation do fluxo completo |
+| "O agente terminou" | Evidence Manifest: comandos, outputs e riscos residuais |
+
+Esse movimento não é preciosismo de engenharia — é a direção do mercado. O Gartner projeta que, até 2027, mais de 65% dos times usando agentic coding tratarão IDEs como opcionais, com controle, governança e validação migrando para plataformas automatizadas (Gartner). O mesmo Gartner projeta que, até o fim de 2026, 40% das aplicações corporativas estarão integradas com agentes de IA task-specific, contra menos de 5% hoje (Gartner). A evidência precisa ser coletável por máquina, porque o volume de mudanças deixa de caber em revisão manual.
+
+E a desconfiança humana justifica o rigor: no Stack Overflow Survey 2025, 46% dos desenvolvedores declararam desconfiar ativamente da precisão de ferramentas de IA, contra 33% que confiam — e os mais experientes são os mais céticos. A resposta organizacional correta a essa desconfiança não é frear a adoção: é institucionalizar a prova.
+
+### [warning]
+O anti-padrão mais caro da era agentic é aceitar o "done" declarado pelo próprio agente. Agentes afirmam conclusão com confiança máxima, inclusive quando a implementação está errada — e um "concluído" sem prova apenas troca falsa confiança humana por falsa confiança automatizada. Trate toda declaração de sucesso de um agente como hipótese a ser verificada, nunca como veredito. A exceção operacional (hotfix crítico com validação posterior) deve ser explícita, registrada e auditada — nunca o caminho padrão.
+
+### [text]
+Adotar "evidência, não afirmação" como política muda o vocabulário do time: "done" deixa de ser um estado declarado e vira um estado provado. A separação decisiva é entre **"gerou código"** e **"entregou resultado verificável"** — e o DORA 2025 dá nome ao custo dessa separação: o **verification tax**, a parte do tempo economizado na escrita de código que é reempregada auditando, revisando e validando output de IA (DORA, 2025).
+
+A boa notícia: esse imposto não precisa ser pago de forma artesanal. As evidências se organizam em dez camadas complementares, cada uma respondendo a uma pergunta distinta:
+
+-- Funcional, regressão, estática e arquitetural — o código faz o que deveria e continua saudável?
+-- Segurança, performance, produto/UX e operacional — a mudança é segura, performa e chega ao usuário?
+-- Agentic e humana — o agente se comporta como esperado, e onde entra o julgamento contextual?
+
+Esse conjunto é o **Quality Evidence Stack**, detalhado na próxima aula. Antes de conhecer as camadas, fixe o princípio que as governa: nenhuma camada isolada prova qualidade; a prova é o conjunto.
+
+### [checkpoint]
+-- **Exercício 1 — Tribunal de evidências.** Selecione 3 entregas marcadas como "done" no último sprint do seu time e submeta cada uma à pergunta reformulada — comportamento preservado, risco reduzido, custo futuro menor. Para cada afirmação sem prova ("funciona", "não quebrou nada"), especifique qual evidência concreta a converteria em fato verificável.
+-- **Exercício 2 — Política de aceite.** Redija a regra de 3 linhas que o seu time adotaria para recusar PRs sem evidência, incluindo as exceções legítimas (por exemplo, hotfix crítico com validação posterior obrigatória e registrada). Avalie se cada exceção se justifica pelo risco que ela aceita.
+
+## Aula 3.2 — Quality Evidence Stack: as dez camadas de evidência de uma entrega agentic
+Meta: id=`quality-evidence-stack-dez-camadas` | duracao=`20 min` | icone=`layers`
+Descrição: Funcional, regressão, estática, arquitetural, segurança, performance, produto/UX, operacional, agentic e humana — cada camada responde a uma pergunta distinta e tem instrumentos próprios.
+
+### [text]
+O **Quality Evidence Stack** organiza a prova de uma entrega agentic em dez camadas — funcional, regressão, estática, arquitetural, segurança, performance, produto/UX, operacional, agentic e humana. Cada camada responde a uma pergunta distinta e usa instrumentos próprios, de unit tests a spot check por risco. Segundo o DORA 2025, a IA amplifica as forças e fraquezas organizacionais: um stack de evidências fraco vira risco amplificado; um stack forte vira confiança amplificada.
+
+Por que dez camadas, e não uma suíte de testes robusta? Porque perguntas diferentes exigem instrumentos diferentes. Um teste unitário que passa não prova que a arquitetura ficou mais simples; um typecheck limpo não prova que o usuário completa o fluxo; um load test não detecta um secret vazado no diff.
+
+O erro clássico do gestor pressionado é tratar "temos CI verde" como sinônimo de "temos evidência". CI verde tipicamente cobre três das dez camadas — funcional, regressão e estática — e deixa as sete restantes no escuro. O stack existe exatamente para tornar esse escuro visível e priorizável.
+
+### [text]
+A tabela completa do stack, com a pergunta que cada camada responde e os instrumentos que a provam:
+
+| Camada de evidência | O que responde | Instrumentos |
+|---|---|---|
+| Funcional | A aplicação faz o que deveria fazer? | unit tests, integration tests, E2E, browser validation |
+| Regressão | O que funcionava antes continua funcionando? | suíte existente, golden tests, testes impactados |
+| Estática | O código respeita contratos e padrões? | typecheck, lint, format, static analysis |
+| Arquitetural | A estrutura ficou mais simples ou mais coerente? | dependency graph, boundaries, ADR, coupling analysis |
+| Segurança | Criamos vulnerabilidade ou exposição? | SAST, dependency scan, secrets scan, OWASP checks |
+| Performance | O sistema continua performando sob carga? | load test, stress test, análise estatística |
+| Produto/UX | O usuário consegue completar o fluxo? | browser run, journey test, acceptance criteria |
+| Operacional | Está seguro para produção? | logs, metrics, rollback, canary, error budget |
+| Agentic | O agente se comporta como esperado? | evals, prompt regression, tool-call assertions |
+| Humana | Há julgamento contextual suficiente? | spot check por risco, revisão de testes, revisão arquitetural |
+
+Leia a tabela como um instrumento de diagnóstico, não como um ideal distante. Nenhuma organização opera as dez camadas com maturidade uniforme — a questão executiva é saber quais camadas estão automatizadas, quais são manuais e quais simplesmente não existem no seu pipeline.
+
+A priorização correta é por **blast radius**: a camada ausente cuja falha causaria o maior dano ao seu produto é a primeira a receber investimento. Em um sistema de billing, segurança e regressão vêm antes de arquitetural; em um produto de consumo, produto/UX e operacional sobem na fila.
+
+### [text]
+Duas camadas merecem atenção especial, porque são as que o SDLC tradicional não previa.
+
+A camada **agentic** é a novidade estrutural do stack. Quando parte da sua produção é executada por agentes, o comportamento do próprio agente vira objeto de teste: evals, prompt regression e tool-call assertions respondem à pergunta "o agente se comporta como esperado?" — uma pergunta que não existia quando todo código era escrito por humanos. O Módulo 4 detalha esses instrumentos, incluindo a matriz de testes para agentes em produção.
+
+A camada **humana** fecha o stack, e sua lógica muda de natureza: o humano não revisa volume, revisa risco. Spot check focado em arquivos críticos, revisão de testes e revisão arquitetural são formas de julgamento contextual que nenhuma automação substitui — mas aplicadas cirurgicamente, onde o blast radius justifica.
+
+> "Não existe uma métrica objetiva universal que diga que o código era nota 5 e virou 10. O que existe é um pacote de evidências." — Alexandre Caramaschi
+
+O DORA 2025 explica por que montar esse pacote é decisão estratégica, não higiene técnica: a IA é um amplificador das forças e fraquezas organizacionais, e o maior ROI não vem da ferramenta isolada, mas do sistema organizacional subjacente (DORA, 2025). Um time com stack de evidências forte amplifica confiança a cada entrega agentic; um time sem stack amplifica risco na mesma velocidade.
+
+### [tip]
+Comece pelo mínimo viável, não pelo stack completo. Automatize primeiro as camadas funcional, regressão e estática — elas têm o melhor custo-benefício e quase sempre já têm ferramenta instalada. Em seguida, ataque a camada ausente de maior blast radius no seu produto específico. Reserve a camada humana para o que ela faz de único: julgamento de risco, arquitetura e testes — nunca para reler diffs inteiros.
+
+### [checkpoint]
+-- **Exercício 3 — Heatmap do stack.** Monte a matriz das 10 camadas contra 3 estados (automatizado / manual / inexistente) para o seu pipeline atual. Identifique a camada cuja ausência tem o maior blast radius no seu produto e justifique a escolha com um cenário real de falha.
+-- **Exercício 4 — MVP de evidência.** Para um microsserviço ou módulo específico do seu sistema, especifique o instrumento concreto de cada camada (nome da suíte, ferramenta de SAST, comando de load test) e estime o custo de implantação em dias. Priorize as três primeiras implantações pelo critério blast radius por dia de esforço.
+
+## Aula 3.3 — Definition of Verified 2.0: o checklist executivo e o Evidence Manifest
+Meta: id=`definition-of-verified-2-0` | duracao=`20 min` | icone=`workflow`
+Descrição: Definition of Verified = Done + evidência automatizada + validação adversarial + revisão humana proporcional ao risco — operacionalizada em um checklist de 15 itens que culmina no Evidence Manifest anexado ao PR ou release.
+
+### [text]
+**Definition of Verified** é a camada acima da Definition of Done exigida quando agentes escrevem código: Done somado a evidência automatizada, validação adversarial e revisão humana proporcional ao risco. Sem esse pacote de provas — testes, scans, revisão de testes e Evidence Manifest anexado ao PR ou release — a entrega agentic não deveria ir para produção, em linha com o TEVV do NIST AI Risk Management Framework.
+
+A Definition of Done continua necessária: critérios de aceite, código integrado, documentação. Mas em ambiente agentic ela não basta, porque foi desenhada para um mundo em que o autor do código era um humano cujo julgamento o time conhecia. Quando o autor é um agente probabilístico, "done" declarado precisa ser promovido a "verified" provado.
+
+A fórmula é direta e cabe em uma linha de política de engenharia:
+
+> Definition of Verified = Done + evidência automatizada + validação adversarial + revisão humana proporcional ao risco.
+
+Cada termo da soma tem função própria. A **evidência automatizada** cobre o volume (as camadas do Quality Evidence Stack que rodam em pipeline). A **validação adversarial** coloca outro agente para tentar encontrar falhas — crítica ativa, não confirmação passiva. E a **revisão humana proporcional ao risco** aloca o recurso mais caro do sistema, o julgamento sênior, onde o blast radius justifica.
+
+### [text]
+Essa abordagem não é invenção isolada: o **NIST AI Risk Management Framework** enfatiza TEVV — test, evaluation, verification and validation — ao longo do ciclo de vida de sistemas de IA, com processos documentados, repetíveis e escaláveis para medir e acompanhar riscos emergentes (NIST AI RMF). Documentado, repetível e escalável é exatamente o que um checklist executivo entrega — e o que uma cultura de "confia no agente" não entrega.
+
+O checklist da Definition of Verified 2.0 tem 15 itens, cada um com sua evidência mínima:
+
+| # | Item | Evidência mínima |
+|---|---|---|
+| 1 | Spec vinculada | intenção, non-goals, restrições e critérios de aceite |
+| 2 | Plano de validação | o que será provado e por quais testes/ferramentas |
+| 3 | Teste vermelho quando aplicável | comportamento desejado falha antes da implementação |
+| 4 | Red > Green > Refactor | ciclo documentado para mudanças determinísticas |
+| 5 | Build limpo | CI sem falhas |
+| 6 | Typecheck/lint | sem regressões relevantes |
+| 7 | Testes unitários | menor unidade possível cobrindo comportamento |
+| 8 | Testes de integração/E2E | fluxos críticos passando |
+| 9 | Browser validation | aplicação aberta e fluxo validado quando aplicável |
+| 10 | Load/performance test | análise estatística quando performance importa |
+| 11 | Security/dependency scan | vulnerabilidades, secrets e dependências avaliadas |
+| 12 | Revisão de testes | humano ou agente sênior avalia se os testes fazem sentido |
+| 13 | Revisão adversarial | outro agente tenta encontrar falhas |
+| 14 | Spot check humano | focado em arquivos críticos e alto blast radius |
+| 15 | Rollback/canary | plano de reversão e implantação segura |
+
+Note a arquitetura do checklist: os itens 1-2 ancoram a entrega na intenção (spec e plano); os itens 3-11 são evidência majoritariamente automatizável; os itens 12-14 são as três formas de revisão — de testes, adversarial e humana por risco; o item 15 garante reversibilidade. O item 12 merece destaque: teste gerado por agente é output, não garantia, e por isso os próprios testes entram na pauta de revisão — tema central do Módulo 4.
+
+### [tip]
+Não implante os 15 itens como gate bloqueante no primeiro dia. Rode o checklist como gate informal ao longo dos próximos 5 PRs relevantes, meça quantos itens passam hoje e use o resultado como baseline de Evidence Completeness — a métrica que o Módulo 6 leva ao painel de board. Gates que nascem bloqueando 100% das entregas morrem em uma semana; gates que nascem medindo sobrevivem e apertam gradualmente.
+
+### [text]
+O item que fecha o ciclo — e que transforma o checklist em ativo auditável — é o **Evidence Manifest**: um resumo anexado ao PR ou release com os comandos executados, os outputs obtidos e os riscos residuais. Testes que rodaram, testes que falharam, testes que foram pulados e por quê, onde houve spot check humano, o que ficou sem cobertura.
+
+O manifest muda a economia da revisão. O revisor deixa de reconstruir mentalmente o que o agente fez e passa a auditar um dossiê estruturado — julgando riscos e deltas em minutos, em vez de reler diffs por horas. É a materialização, no nível do PR, do princípio de revisar por risco e não por volume.
+
+> "A entrega não é o agente concluiu. A entrega é: o pacote de evidências sustenta que a mudança é correta, segura e aderente à intenção." — Alexandre Caramaschi
+
+Há também um argumento de sobrevivência institucional. O Gartner projeta que, até 2027, 40% das empresas descomissionarão ou rebaixarão agentes autônomos por falhas de governança (Gartner) — e a Definition of Verified é precisamente a infraestrutura de governança que separa quem escala agentes de quem os desliga. Com o gate e o manifest operando, o time está pronto para a próxima camada do operating model: usar TDD e evals como mecanismos de controle do próprio agente, tema do Módulo 4.
+
+### [checkpoint]
+-- **Exercício 5 — Gate piloto.** Aplique o checklist de 15 itens ao próximo PR relevante do seu time como gate informal (sem bloquear merge) e meça quantos itens passam hoje. Use o resultado como baseline de Evidence Completeness e projete a meta trimestral — quais 3 itens sobem primeiro e com qual investimento.
+-- **Exercício 6 — Template de Evidence Manifest.** Crie o template markdown do manifesto para o seu repositório — comandos executados, outputs, testes pulados e a justificativa, riscos residuais, onde houve spot check humano — e proponha o ponto exato do CI onde ele é gerado automaticamente. Avalie se o template atende ao critério TEVV do NIST: documentado, repetível, escalável.

--- a/output/drafts/agentic-operating-model/modulo-4.md
+++ b/output/drafts/agentic-operating-model/modulo-4.md
@@ -1,0 +1,167 @@
+# Módulo 4 — Controle de Agentes: TDD, Revisão de Testes e Evals em Produção
+
+## Aula 4.1 — TDD volta ao centro: Red > Green > Refactor como mecanismo de controle de agente
+Meta: id=`tdd-mecanismo-de-controle-de-agente` | duracao=`20 min` | icone=`workflow`
+Descrição: Antes, TDD era técnica de qualidade de código; com agentes, o teste vira contrato — o agente gera a implementação, mas não decide sozinho o que é sucesso.
+
+### [text]
+TDD ganhou uma segunda vida na era agentic: de técnica de qualidade de código, o ciclo Red > Green > Refactor virou mecanismo de controle de output probabilístico. O teste escrito antes da implementação funciona como contrato — o agente gera o código, mas não decide sozinho o que é sucesso. Segundo Martin Fowler, em 2026, o TDD tornou o desenvolvimento assistido por IA sustentável em vez de caótico, mantendo o humano no loop.
+
+Você provavelmente já travou esse debate uma década atrás. **TDD** (Test-Driven Development) dividiu times entre entusiastas do design emergente e céticos do custo de manutenção de testes. O ciclo clássico, na formulação de Martin Fowler, é direto: escreva o teste para o comportamento desejado, escreva código até o teste passar, refatore com a segurança da suíte verde.
+
+O argumento histórico a favor sempre foi de engenharia: o teste primeiro força clareza de interface e impede a bagunça incremental. O argumento contra sempre foi de economia: escrever teste antes custa tempo de dev sênior. Agentes de IA mudaram os dois lados dessa conta ao mesmo tempo.
+
+> "O teste vira contrato. O agente pode gerar código, mas não decide sozinho o que é sucesso." — Alexandre Caramaschi
+
+O que mudou de verdade:
+
+-- O custo de escrever a implementação despencou — o agente gera o código em minutos, não em dias.
+-- O custo de aceitar implementação errada explodiu — output probabilístico produz código plausível que compila, roda e faz a coisa errada com confiança.
+-- O **teste vermelho** escrito antes da delegação passa a ser o único artefato que define sucesso independentemente do agente que executa.
+
+Fowler observou exatamente esse deslocamento em 2026: em desenvolvimento assistido por IA, o TDD deixou o workflow sustentável em vez de caótico. A razão é andragógica antes de ser técnica — não dá para escrever um teste significativo sem entender o que está sendo construído. O teste é a prova de que houve intenção humana antes da geração.
+
+### [text]
+A pergunta prática do CTO não é "adotamos TDD?", e sim "quem é dono de cada etapa quando um agente entra no meio do ciclo?". O **pipeline recomendado** tem sete etapas, cada uma com dono explícito:
+
+Spec → Teste vermelho → Implementação agentic → Teste verde → Refactor → Validação adversarial → Evidence Manifest
+
+A tabela de donos por etapa resolve a ambiguidade que hoje trava a maioria dos times:
+
+| Etapa | O que acontece | Dono |
+|---|---|---|
+| Intenção | Problema, restrições e não-objetivos definidos | PM / founder |
+| Critérios de sucesso | O que é verificável e mensurável | PM + Tech Lead |
+| Teste vermelho | Contrato escrito antes do código | Dev ou agente sob supervisão humana |
+| Implementação | Código gerado até o teste passar | Agente executor |
+| Refactor | Limpeza estrutural com suíte verde | Agente + humano |
+| Verificação | Evidências coletadas e criticadas | CI + agente revisor + humano por risco |
+| Aceite | Decisão de que a entrega vale | Produto / owner |
+
+Repare no padrão: o humano concentra-se nas pontas — intenção, critérios, contrato e aceite — e a máquina ocupa o meio. O agente executor nunca é dono da etapa que define o que é sucesso nem da que decide se a entrega vale. Essa separação é o mecanismo de controle; o resto é ferramenta.
+
+A etapa de **validação adversarial** merece atenção especial: um segundo agente (ou o orquestrador) critica a implementação contra a spec antes de qualquer humano gastar atenção. O Evidence Manifest, apresentado no Módulo 3, fecha o ciclo — o pipeline não termina quando o teste passa, termina quando a evidência está anexada.
+
+### [tip]
+Comece pelo contrato, não pela ferramenta. Na próxima tarefa que você delegar a um agente, escreva primeiro dois ou três testes vermelhos que capturam o comportamento esperado — inclusive um caso de borda — e só então entregue a spec ao agente. Se você não consegue escrever o teste, o problema não é o agente: é que a intenção ainda não está clara o suficiente para ser delegada.
+
+### [text]
+Por que isso mantém o humano no loop de forma estrutural, e não performática? Porque escrever um teste significativo exige compreender o domínio, a interface e o comportamento esperado. Um gestor pode pular a leitura do diff de 800 linhas; não pode pular a definição do que é sucesso sem abrir mão do controle.
+
+Há também um efeito econômico direto, documentado pelo relatório DORA (2025) como **verification tax**: parte do tempo economizado na escrita de código é reempregado auditando, revisando e validando output de IA. O teste-contrato reduz esse imposto porque automatiza a primeira camada da auditoria — a suíte responde "o comportamento contratado existe?" antes de qualquer olho humano.
+
+> Teste antes do código deixou de ser preferência metodológica. Em delivery agentic, é a diferença entre delegar e abdicar.
+
+A conclusão operacional: TDD não voltou como moda de engenharia — voltou como instrumento de governança. O teste é o contrato operacionalizável entre a intenção humana e a execução probabilística. Times que tratam Red > Green > Refactor como burocracia estão, na prática, deixando o agente decidir sozinho o que é sucesso.
+
+### [checkpoint]
+-- **Exercício 1 — RACI do pipeline.** Preencha a tabela de donos das sete etapas (Spec, Teste vermelho, Implementação, Teste verde, Refactor, Validação adversarial, Evidence Manifest) para o seu time real, nomeando pessoas e agentes. Identifique a etapa órfã — tipicamente a validação adversarial — e proponha um dono com nome e rito.
+-- **Exercício 2 — Contrato antes do código.** Escolha uma tarefa do backlog e escreva os testes vermelhos ANTES de delegar ao agente. Depois compare o diff entregue com o que você teria aceito sem o contrato — documente as diferenças e apresente ao time como evidência do valor do teste-contrato.
+
+## Aula 4.2 — Teste gerado por agente é output, não garantia: os oito vícios e a pesquisa TDAD
+Meta: id=`testes-gerados-por-ia-tdad` | duracao=`20 min` | icone=`layers`
+Descrição: Teste ruim é anestesia corporativa: agentes escrevem testes que confirmam a implementação errada, mockam demais e reduzem tudo a happy path — a regressão precisa virar métrica de primeira classe.
+
+### [text]
+Teste gerado por agente é output, não garantia. Agentes escrevem testes que confirmam a implementação errada, mockam demais, ignoram edge cases e reduzem tudo a happy path — oito vícios catalogados que fabricam confiança sem fabricar segurança. A pesquisa TDAD (arXiv 2603.17973, 2026) mostra que agentes resolvem uma issue e quebram testes anteriores, e propõe regressão como métrica de primeira classe. A resposta operacional é um rito formal de **revisão de testes**.
+
+A aula anterior estabeleceu o teste como contrato. Essa aula ataca a falha lógica que compromete esse contrato: se o mesmo agente que escreve o código escreve os testes, quem garante o contrato? A frase "o agente escreveu testes" descreve um artefato produzido, não uma verificação realizada.
+
+Há dado externo sustentando a desconfiança. Segundo a Stack Overflow Survey 2025, 46% dos desenvolvedores desconfiam ativamente da precisão de ferramentas de IA, contra 33% que confiam — e os desenvolvedores mais experientes são os mais céticos. O ceticismo dos seniores não é resistência cultural: é reconhecimento de padrão.
+
+> "Teste gerado por agente é output, não garantia." — Alexandre Caramaschi
+
+### [warning]
+Teste ruim é anestesia corporativa. Uma suíte com centenas de testes verdes gerados por IA pode passar integralmente com o comportamento errado em produção — e o dashboard verde desativa exatamente o instinto de auditoria que salvaria a entrega. O pior cenário não é o time sem testes; é o time que parou de olhar porque "os testes passam". Cobertura alta com testes viciados é passivo disfarçado de ativo.
+
+### [text]
+Os oito vícios catalogados dos testes gerados por agentes formam um checklist de auditoria direto:
+
+| # | Vício | O que parece | O que esconde |
+|---|---|---|---|
+| 1 | Confirmar a implementação errada | Teste alinhado ao código | O teste foi escrito olhando o bug, e o valida |
+| 2 | Mockar demais | Isolamento limpo | Nada real é exercitado; só o mock é testado |
+| 3 | Testar detalhes irrelevantes | Cobertura alta | Estrutura interna testada, comportamento não |
+| 4 | Ignorar edge cases | Suíte enxuta | Nulos, limites e concorrência sem cobertura |
+| 5 | Passar com comportamento incorreto | Verde no CI | Assertions fracas ou tautológicas |
+| 6 | Atualizar snapshots sem análise | Suíte "corrigida" | Regressão aceita como novo baseline |
+| 7 | Reduzir tudo a happy path | Fluxo principal coberto | Erros, timeouts e falhas parciais ignorados |
+| 8 | Criar falsa confiança | Métricas boas | Decisões de merge baseadas em teatro |
+
+O vício 6 é o mais silencioso e o mais corrosivo. Atualizar um snapshot é um clique; analisar por que ele mudou exige contexto. Agentes otimizam para suíte verde — e a forma mais rápida de deixar a suíte verde é aceitar o novo comportamento como correto.
+
+Os vícios 1 e 5 são os que quebram o contrato da aula anterior: se o teste foi escrito depois do código, olhando o código, ele valida o que foi feito — não o que deveria ter sido feito. É a inversão exata do Red > Green > Refactor.
+
+### [text]
+A pesquisa **TDAD** (Test-Driven Agentic Development, arXiv 2603.17973, 2026) deu forma empírica ao problema. Os autores mostram que benchmarks focados apenas em resolução de tarefa ignoram regressões: agentes resolvem a issue proposta e, no mesmo movimento, quebram testes anteriores. A tarefa fecha; o sistema piora.
+
+Duas contribuições do estudo importam para quem lidera times de engenharia:
+
+-- Regressão como **métrica de primeira classe** — medir só "resolveu a tarefa?" é medir metade do trabalho; a outra metade é "preservou o que funcionava?".
+-- Redução relevante de regressões quando os agentes são guiados por **grafos de dependência** entre código e testes — o agente que enxerga o que sua mudança impacta quebra menos.
+
+A resposta organizacional é um rito de revisão de testes com a postura certa. A analogia que calibra o rigor: revise o trabalho do agente como revisaria o de um júnior brilhante, rápido e perigosamente confiante. Você não descartaria o trabalho do júnior — mas também não faria merge sem ler as assertions, questionar os mocks e perguntar onde estão os casos de erro.
+
+Esse rito não é overhead solto: ele já tem lugar reservado no operating model. A revisão de testes é item do checklist da Definition of Verified (Módulo 3), e Test Review Coverage e Regression Rate entram no painel de board do Módulo 6. O que essa aula acrescenta é o método — os oito vícios como pauta objetiva da revisão.
+
+### [checkpoint]
+-- **Exercício 3 — Caça aos vícios.** Audite 10 testes gerados por IA no seu repositório contra a lista dos oito vícios. Classifique cada teste e calcule a proporção de anestesia — testes que passariam mesmo com comportamento incorreto (vícios 1, 5 e 7). Apresente o número ao time como baseline de Test Review Coverage.
+-- **Exercício 4 — Política de snapshot.** Escreva a regra do time para atualização de snapshots por agentes — quando é permitida, quem revisa, qual evidência acompanha o commit. É o vício mais silencioso da lista; a política de três linhas elimina a maior parte do risco.
+-- **Exercício 5 — Regressão como métrica.** Usando a lógica da TDAD, defina como seu CI passaria a reportar "issues resolvidas × testes anteriores quebrados" por PR de agente — e qual threshold bloqueia o merge.
+
+## Aula 4.3 — Evals de agentes em produção e Nightly Agentic Verification: o code review que revisa evidências
+Meta: id=`evals-producao-nightly-agentic-verification` | duracao=`20 min` | icone=`scale`
+Descrição: Testar um agente em produção é outro universo — golden prompts, policy tests, drift tests, telemetria — e a validação estruturada roda à noite, entregando pela manhã um Evidence Manifest para revisão humana por risco.
+
+### [text]
+Testar um agente em produção exige uma matriz própria: golden prompts, regression prompts, prompts adversariais, tool-call assertions, policy tests, memory tests, drift tests, hidden evals, mutation tests, human preference review e telemetria — onze tipos que unit tests não cobrem. A **Nightly Agentic Verification** operacionaliza a disciplina: o orquestrador roda a validação estruturada à noite e entrega pela manhã um Evidence Manifest para revisão humana por risco.
+
+A distinção decisiva vem antes da ferramenta. Testar uma função determinística é verificar que a mesma entrada produz a mesma saída — unit, integration, E2E, typecheck, load. Testar um agente que recebe prompts, usa ferramentas, consulta memória e toma ações é outro universo: a mesma entrada pode produzir saídas diferentes, e a falha pode estar na ação tomada, não no texto retornado.
+
+E o problema deixou de ser nicho. Segundo o Gartner, até o fim de 2026, 40% das aplicações corporativas estarão integradas com agentes de IA task-specific, contra menos de 5% no início do período — cada uma dessas integrações é um agente em produção que alguém precisa validar continuamente. A matriz dos onze tipos de teste para agente em produção:
+
+| Tipo de teste | O que verifica |
+|---|---|
+| Golden prompts | Casos canônicos continuam produzindo a resposta esperada |
+| Regression prompts | Mudança de modelo/prompt não degradou casos já resolvidos |
+| Adversarial prompts | Resistência a prompt injection e instruções maliciosas |
+| Tool-call assertions | O agente chama as ferramentas certas, com os argumentos certos |
+| Policy tests | Regras de negócio e limites de conduta são respeitados |
+| Memory tests | A memória não contamina nem vaza contexto entre sessões |
+| Drift tests | O comportamento não se degrada silenciosamente ao longo do tempo |
+| Hidden evals | Avaliações que o agente não conhece e não pode otimizar |
+| Mutation tests | Pequenas variações de entrada não invertem a decisão |
+| Human preference review | Amostras julgadas por humanos contra critérios de qualidade |
+| Telemetria em produção | O comportamento real, medido onde importa |
+
+### [text]
+Por que essa matriz precisa existir como controle formal, e não como boa vontade do time? Porque os riscos são específicos e catalogados. O OWASP LLM Top 10 lista prompt injection, insecure output handling, model denial of service, insecure plugin design, excessive agency e overreliance; o OWASP Gen AI Security Project (Agentic AI Threats) trata agentes como categoria com riscos próprios — autonomia, uso de ferramentas, memória, subagentes e tomada de decisão.
+
+Nenhum unit test detecta excessive agency. Nenhuma suíte de integração pega um drift de comportamento após troca de modelo. Para agentes, teste não é só unit test — é eval, política, telemetria e controle de agência. Desse conjunto nasce um campo de prática próprio: **Agent Evaluation Engineering**.
+
+O custo de ignorar isso já tem número (Gartner, previsão para 2027): 40% das empresas descomissionarão ou rebaixarão agentes autônomos por falhas de governança. Evals em produção são a linha de defesa que separa o agente auditável do agente que será desligado.
+
+A **Nightly Agentic Verification** transforma a matriz em rotina. No fim do dia, o orquestrador de testes roda o ciclo completo:
+
+-- Testes impactados pelo diff do dia e suíte mínima de regressão.
+-- Integração, E2E e validação no browser.
+-- Load test, análise estática e security scan.
+-- Revisão adversarial por agente e comparação do resultado com as specs.
+-- Geração do **Evidence Manifest** consolidado — comandos, outputs, falhas e riscos residuais.
+
+Na manhã seguinte, o humano não revisa tudo: revisa evidências, falhas, deltas críticos, testes novos, arquivos de alto risco e recomendações. Revisão por risco, não por volume — o princípio do Módulo 2 aplicado à rotina diária. É a mesma direção que o Gartner projeta para 2027: mais de 65% dos times usando agentic coding com controle, governança e validação migrando para plataformas automatizadas.
+
+A base determinística disso existe hoje: os hooks do Claude Code, na documentação da Anthropic, executam comandos de shell automaticamente quando o agente edita arquivos, completa tarefas ou precisa de input — controle determinístico em vez de comportamento probabilístico. E o critério do que entra no manifesto segue a regra das boas práticas do Claude Code: "peça evidências, não afirmações" — evidência pode ser saída de teste, comando, screenshot ou log.
+
+> "O futuro do code review não é revisar mais linhas. É revisar melhores evidências." — Alexandre Caramaschi
+
+### [warning]
+O erro mais comum ao montar evals é publicar todos os critérios para o próprio agente — que passa a otimizar para o eval em vez de para o comportamento correto. Mantenha hidden evals fora do contexto do agente e trate overreliance (OWASP) como risco do lado humano: a revisão matinal que vira carimbo automático depois de duas semanas de manifests verdes é o mesmo vício da anestesia de testes, um nível acima.
+
+### [tip]
+Não comece pelos onze tipos: comece com cinco golden prompts, três adversarial prompts e dois policy tests para um único agente em produção, com threshold explícito de aprovação. Agende a primeira Nightly Agentic Verification só com o que seu CI já roda hoje — testes impactados, lint e security scan — e acrescente uma camada por semana. A pauta matinal cabe em 15 minutos se o manifesto for bem estruturado.
+
+### [checkpoint]
+-- **Exercício 6 — Suíte mínima de evals.** Para um agente em produção (ou planejado) da sua empresa, escreva 5 golden prompts, 3 adversarial prompts — incluindo ao menos um de prompt injection — e 2 policy tests. Defina o threshold de aprovação e o que acontece quando ele é violado (bloqueio, alerta, rollback).
+-- **Exercício 7 — Desenho do nightly.** Especifique o pipeline de Nightly Agentic Verification do seu repositório principal — o que roda, em que ordem, o que entra no Evidence Manifest — e redija a pauta de 15 minutos da revisão matinal, separando o que o humano lê sempre do que só lê quando falha.
+-- **Exercício 8 — Mapa de risco OWASP.** Cruze os agentes do seu ambiente com os riscos do OWASP LLM Top 10 e do Agentic AI Threats — para cada par agente × risco relevante, aponte qual dos onze tipos de teste o cobre hoje e onde não há cobertura alguma.

--- a/output/drafts/agentic-operating-model/modulo-5.md
+++ b/output/drafts/agentic-operating-model/modulo-5.md
@@ -1,0 +1,146 @@
+# Módulo 5 — Humanos, Governança e Specs: o Sistema Nervoso do Operating Model
+
+## Aula 5.1 — Não é um júnior: é um júnior com alavancagem de staff engineer e julgamento não confiável
+Meta: id=`humano-muda-de-funcao` | duracao=`20 min` | icone=`users`
+Descrição: O humano não sai do loop — deixa de escrever código e revisar linha a linha para definir intenção, criar specs, revisar evidência e risco, e gerenciar dívida de validação.
+
+### [text]
+O agente de código não é um júnior comum: é um executor com alavancagem operacional de **staff engineer** — milhões de tokens processados, um diff gigantesco entregue em 45 minutos — combinada a um julgamento que ainda não é confiável. Por isso o humano não sai do loop: ele muda de função, de escritor de código para auditor de intenção, evidência e risco. Essa transição redefine o papel de todo sênior na organização.
+
+A analogia que circula entre times é conhecida: "avalie o output do agente como avaliaria o de um júnior". Ela funciona como porta de entrada, mas o documento-fonte a corrige com uma ressalva decisiva. Nenhum júnior humano produz um diff de milhares de linhas em menos de uma hora atravessando dezenas de arquivos.
+
+> A combinação é inédita: velocidade e alcance de staff engineer, julgamento de alguém que você ainda não pode deixar sozinho. Governar essa assimetria é o trabalho novo do humano.
+
+Os dados sustentam o ceticismo estruturado. Segundo o **Stack Overflow Survey 2025**, 46% dos desenvolvedores desconfiam ativamente da precisão de ferramentas de IA, contra 33% que confiam — e os desenvolvedores mais experientes são exatamente os mais céticos. A verificação humana não é resistência cultural: é resposta racional à assimetria entre alavancagem e julgamento.
+
+### [text]
+Se o julgamento do agente não é confiável e a velocidade dele é ordens de grandeza maior, revisar linha a linha vira matematicamente impossível. A saída não é revisar mais — é mudar o que se revisa. O documento-fonte mapeia essa mudança na tabela antes/agora das funções do humano:
+
+| Antes (SDLC tradicional) | Agora (Agentic Operating Model) |
+|---|---|
+| Escrever código | Definir intenção, restrições e critérios de sucesso |
+| Revisar cada linha | Revisar evidência e risco |
+| Estimar esforço | Estimar risco, custo de validação e confiança |
+| Gerenciar sprint | Gerenciar fluxo, agentes e dívida de validação |
+| Detalhar tarefas no backlog | Criar **specs verificáveis** |
+| Aceitar "done" na palavra | Exigir pacote de evidências |
+| Executar QA no final | Auditar pontos de decisão, exceções e alto blast radius |
+
+A coluna da direita descreve o humano como **auditor de intenção e risco**: ele revisa spec, testes, evidências, riscos, pontos de decisão e tudo que tem alto blast radius. O que é rotineiro e de baixo risco desce para validação automatizada; o que é ambíguo, irreversível ou caro de errar sobe para o julgamento humano.
+
+Há uma consequência econômica direta. Conforme o relatório DORA (2025), parte do tempo economizado na escrita de código é reempregado auditando, revisando e validando output de IA — fenômeno que o relatório nomeia de **verification tax**. A conta real da era agentic é essa — a IA reduz o custo de geração, mas aumenta a importância econômica da verificação.
+
+### [tip]
+Ao redistribuir o tempo dos seus sêniores, comece pelo blast radius, não pelo volume. Um sênior que passa duas horas por dia revisando evidências de mudanças em billing, autenticação e migrations protege mais valor do que um que revisa linha a linha vinte PRs de baixo risco. Use a coluna "agora" da tabela como job description provisória e ajuste a cada trimestre.
+
+### [text]
+A objeção previsível é que essa mudança "burocratiza" o trabalho. O argumento inverte a realidade: se você já tentou revisar linha a linha um diff de milhares de linhas gerado por agente, provavelmente já pagou o verification tax de forma desorganizada — revisando tudo com a mesma atenção e, portanto, revisando mal. Quem muda de função paga o mesmo imposto de forma deliberada — concentrado onde o risco mora.
+
+Isso também explica por que os mais experientes são os mais céticos no Stack Overflow Survey 2025: eles reconhecem os padrões de erro que um output fluente esconde. Esse ceticismo é ativo, não paralisante. Ele se converte em specs melhores, testes-contrato e revisão por risco — os mecanismos dos módulos 3 e 4, agora com dono.
+
+O saldo entre tempo economizado gerando e tempo gasto validando é mensurável. Ele reaparece no Módulo 6 como **AI Delivery Drag**, uma das quinze métricas do painel de board. A função nova do humano é justamente manter esse saldo positivo.
+
+### [checkpoint]
+-- **Exercício 1 — Redesenho de papel.** Para cada sênior do seu time, mapeie a distribuição de tempo atual entre as colunas "antes" e "agora" da tabela das sete funções. Proponha a realocação-alvo para o próximo trimestre e liste o que precisa existir antes (specs, evals, Evidence Manifests) para viabilizá-la.
+-- **Exercício 2 — Análise do verification tax.** Meça em um sprint quanto tempo o time gastou validando output de IA versus quanto economizou gerando. Justifique o saldo encontrado — ele é o seu AI Delivery Drag local e será baseline no Módulo 6.
+-- **Exercício 3 — Diagnóstico de ceticismo.** Com base na sua experiência como profissional, compare a postura dos seus devs mais e menos experientes frente ao output de agentes com o padrão do Stack Overflow Survey 2025 (46% desconfiam, 33% confiam). Avalie se o ceticismo dos sêniores está sendo convertido em mecanismo (testes, spot checks) ou desperdiçado em retrabalho.
+
+## Aula 5.2 — Governança proporcional ao risco: os seis níveis de autonomia L0-L5 e os doze guardrails mínimos
+Meta: id=`autonomia-l0-l5-guardrails` | duracao=`20 min` | icone=`shield`
+Descrição: Não se aplica a mesma liberdade a um agente que lê documentação e a outro que altera billing: a autonomia é graduada de read-only a critical autonomy, com controles crescentes.
+
+### [text]
+Governança agentic não é um interruptor liga/desliga: é uma escala de seis níveis de autonomia, de **L0 (read-only)** a **L5 (critical autonomy)**, em que cada degrau adiciona permissões e exige controles proporcionais. Um agente que lê documentação não carrega o mesmo risco de um agente que altera billing, deploy, permissões ou dados de cliente. O princípio operacional: autonomia se concede por nível de risco, nunca por conveniência.
+
+O erro mais comum das organizações é tratar "agente" como categoria única. Na prática, o mesmo modelo pode operar como analista inofensivo pela manhã e como operador de produção à tarde — e o controle precisa acompanhar a operação, não a ferramenta. A escala do problema cresce rápido. Segundo o Gartner, até o fim de 2026, 40% das aplicações corporativas estarão integradas com agentes de IA task-specific, contra menos de 5% hoje — cada integração nova é mais um ponto de autonomia que alguém precisa classificar e controlar.
+
+A pressão para acertar isso não é teórica. O **OWASP Gen AI Security Project** cataloga as **Agentic AI Threats** como categoria própria de risco: autonomia, uso de ferramentas, memória, subagentes e tomada de decisão. No centro está a **Excessive Agency** — ferramentas, permissões ou autonomia excessivas que transformam uma alucinação, um prompt injection ou uma extensão comprometida em ação danosa real.
+
+### [warning]
+Segundo o Gartner (previsão para 2027), 40% das empresas irão descomissionar ou rebaixar agentes autônomos por falhas de governança. O padrão da falha é sempre o mesmo: autonomia concedida acima do que os controles sustentam, incidente, e retrocesso generalizado que queima a credibilidade do programa inteiro. O guia conjunto dos Five Eyes para agentic AI em infraestrutura crítica aponta a mesma direção — visibilidade, assurance e alinhamento com modelos de segurança existentes, sem jamais conceder acesso amplo ou irrestrito.
+
+### [text]
+O modelo de graduação do documento-fonte organiza a autonomia em seis níveis:
+
+| Nível | Nome | Permissão | Exemplo | Controle mínimo |
+|---|---|---|---|---|
+| L0 | Read-only | Lê repo e docs, sem escrita | Análise de repositório, triagem | Audit logs |
+| L1 | Draft | Produz rascunhos que o humano aplica | Sugestão de código e documentação | Revisão humana integral |
+| L2 | PR sandbox | Escreve em branch isolada e abre PR | Implementação com CI completo | Branch protection + gates de CI |
+| L3 | Act with approval | Executa ações mediante aprovação explícita | Merge, migration, deploy em staging | Approval gates + audit logs |
+| L4 | Bounded autonomy | Age sozinho dentro de limites definidos | Rotinas repetíveis com allowlist e budget | Allowlist, budget caps, circuit breakers, rollback |
+| L5 | Critical autonomy | Produção sensível (billing, permissões, dados de cliente) | Ação autônoma em sistema crítico | Governança pesada — ou nível evitado |
+
+A leitura executiva da tabela: a maioria dos times deveria operar entre L1 e L3 hoje, subir para L4 apenas em fluxos com validação madura, e tratar L5 como exceção justificada caso a caso — muitas vezes a decisão correta é não conceder.
+
+Sustentando a escala, o documento-fonte define os **doze guardrails mínimos** de qualquer operação agentic:
+
+-- **Least privilege**: cada agente com o mínimo de acesso necessário à tarefa.
+-- **Command allowlist**: comandos permitidos enumerados, não inferidos.
+-- **Protected files**: arquivos sensíveis fora do alcance de escrita.
+-- **Branch protection**: nenhuma escrita direta em branches protegidas.
+-- **Budget caps**: teto de tokens e custo por execução e por período.
+-- **Audit logs**: toda ação registrada e atribuível.
+-- **Approval gates**: aprovação humana explícita em cada ponto definido.
+-- **Rollback automático**: toda mudança reversível por mecanismo, não por heroísmo.
+-- **Canary deploy**: exposição gradual antes de tráfego total.
+-- **Circuit breakers**: interrupção automática ao detectar comportamento anômalo ou estouro de budget.
+-- **Segregation of duties**: quem executa não aprova; quem aprova não executa.
+-- **Human approval para alto blast radius**: nenhuma ação de dano potencial amplo sem humano no gate.
+
+### [tip]
+Implante a escala pelo caminho inverso do entusiasmo: comece classificando o que já roda (CI bots, crons, agentes de código) antes de autorizar qualquer coisa nova. Na prática, três guardrails destravam a subida de nível com mais frequência — budget caps, circuit breakers e segregation of duties — porque são os que faltam em setups montados às pressas. A síntese do documento-fonte vale como critério de decisão: "A governança boa não mata velocidade. Ela impede que velocidade vire passivo." — Alexandre Caramaschi
+
+### [checkpoint]
+-- **Exercício 4 — Censo de autonomia.** Inventarie todos os agentes e automações com acesso ao seu ambiente no seu dia a dia (CI bots, agentes de código, crons) e classifique cada um em L0-L5. Sinalize os que operam acima do nível que o controle atual sustenta — esses são os candidatos ao cenário Gartner de descomissionamento até 2027.
+-- **Exercício 5 — Gap de guardrails.** Para o agente de maior autonomia do censo, verifique os doze guardrails um a um e projete o plano de 30 dias para fechar os três gaps mais críticos, com dono e evidência de fechamento por item.
+-- **Exercício 6 — Julgamento de L5.** Escolha um fluxo sensível da sua operação (billing, permissões ou dados de cliente) e justifique por escrito, em dez linhas, a decisão de conceder ou vetar autonomia L5 — usando Excessive Agency (OWASP) e o guia Five Eyes como critérios.
+
+## Aula 5.3 — SDD como sistema nervoso: do Spec Kit ao Spec Acceptance Pack de onze artefatos
+Meta: id=`sdd-spec-acceptance-pack` | duracao=`20 min` | icone=`file-text`
+Descrição: Spec-Driven Development deixou de ser boa prática e virou infraestrutura: agentes são literal-minded pair programmers, e sem intent, non-goals, risk map e evidence requirements a entrega é vibe shipping com verniz corporativo.
+
+### [text]
+**Spec-Driven Development (SDD)** deixou de ser boa prática de documentação e virou infraestrutura do Agentic Operating Model: é a spec que conecta a intenção humana à validação automatizada, funcionando como contrato executável entre quem define o problema e o agente que o resolve. Sem spec verificável, a governança da aula anterior não tem o que proteger e a validação dos módulos 3 e 4 não tem contra o que verificar.
+
+A razão é da natureza dos agentes. O **GitHub Blog** os define como "literal-minded pair programmers" — parceiros de programação que interpretam ao pé da letra e, por isso, precisam de instruções não ambíguas. Cada frase vaga em uma issue não desaparece: ela transfere a decisão para o agente, que decidirá com o julgamento não confiável da Aula 5.1.
+
+O fluxo de referência é o **Spec Kit** (Microsoft Developer): requisitos transformados em planos, tarefas e validação através de sete fases — **Constitution, Specify, Clarify, Plan, Tasks, Implement, Validate**. O argumento central da Microsoft é econômico: clareza cedo reduz retrabalho caro depois. Boas specs capturam intenção, restrições e critérios de aceite antes de qualquer token ser gasto em implementação.
+
+### [text]
+Martin Fowler e a Thoughtworks descrevem a maturidade dessa prática em três níveis: **spec-first** (a spec existe antes do código), **spec-anchored** (o código permanece ancorado na spec ao longo da evolução) e **spec-as-source** (a spec é a fonte de verdade da qual código e testes derivam). Em todos, a spec é fonte de verdade compartilhada entre humano e agente — artefato vivo, não documento morto.
+
+Para operacionalizar, o documento-fonte propõe o **Spec Acceptance Pack**: onze artefatos, cada um respondendo a uma pergunta que, sem resposta explícita, vira decisão implícita do agente.
+
+| Artefato | Pergunta que responde |
+|---|---|
+| Intent | Qual problema estamos resolvendo? |
+| Non-goals | O que está explicitamente fora do escopo? |
+| Acceptance criteria | O que prova, de forma verificável, que a entrega atendeu? |
+| Risk map | O que pode dar errado e qual o blast radius? |
+| Architecture constraints | Que limites de arquitetura o código deve respeitar? |
+| Test strategy | Como a mudança será testada, e em que camadas? |
+| Agent policy | O que o agente pode decidir sozinho e o que escala para humano? |
+| Tool permissions | Quais ferramentas e acessos o agente recebe (nível L0-L5)? |
+| Rollback plan | Como a mudança é desfeita se algo falhar? |
+| Evidence requirements | Quais provas devem acompanhar a entrega no Evidence Manifest? |
+| Budget | Quanto token, tempo e custo podemos queimar? |
+
+Repare como o pack costura o curso inteiro: acceptance criteria e evidence requirements alimentam a Definition of Verified (Módulo 3); test strategy alimenta o TDD como contrato (Módulo 4); agent policy e tool permissions materializam o L0-L5 desta aula; budget conecta com o model routing (Módulo 2) e com as métricas de board (Módulo 6).
+
+### [tip]
+Não transforme o pack em burocracia de onze documentos: os onze artefatos cabem em uma página. Preencha na ordem intent, non-goals e acceptance criteria primeiro — se esses três não saírem em minutos, a entrega não está pronta para ser delegada a agente nenhum. Cronometre o exercício: se o pack de uma entrega comum leva mais de 90 minutos, o gargalo está na clareza da intenção, não no template.
+
+### [text]
+A régua de corte do documento-fonte é direta:
+
+> "Sem isso, não é AI-native engineering. É vibe shipping com verniz corporativo." — Alexandre Caramaschi
+
+"Vibe shipping" é o anti-padrão: delegar a partir de uma frase vaga, aceitar o diff porque parece bom e chamar de inovação. O verniz corporativo — cerimônias, dashboards, nomenclatura agentic — não muda a natureza do processo se a decisão do que é sucesso continuar implícita.
+
+O contraste define o sistema nervoso do operating model. A spec transporta a intenção (Aula 5.1) até a validação; a governança L0-L5 (Aula 5.2) define com que liberdade o agente percorre esse caminho; o Spec Acceptance Pack registra as decisões para que nenhuma delas seja tomada por omissão. Com esses três elementos, o Módulo 6 pode fechar o modelo com forecast probabilístico e métricas de board — porque passa a existir algo verificável para medir.
+
+### [checkpoint]
+-- **Exercício 7 — Pack em 1 página.** Escolha um problema real do seu roadmap e crie o Spec Acceptance Pack completo, com os onze artefatos em no máximo uma página. Cronometre; se levar mais de 90 minutos, diagnostique onde a intenção está vaga.
+-- **Exercício 8 — Auditoria de ambiguidade.** Pegue 3 issues abertas do backlog e marque cada frase que um "literal-minded pair programmer" interpretaria de duas formas. Reescreva as três piores como acceptance criteria verificáveis.
+-- **Exercício 9 — Avaliação de maturidade SDD.** Classifique seu time em spec-first, spec-anchored ou spec-as-source, justificando com exemplos do último mês — e projete o que precisaria mudar no fluxo de PR para subir um nível em um trimestre.

--- a/output/drafts/agentic-operating-model/modulo-6.md
+++ b/output/drafts/agentic-operating-model/modulo-6.md
@@ -1,0 +1,187 @@
+# Módulo 6 — O Operating Model Completo: Forecast, Métricas de Board, Tiny Teams e Cadência
+
+## Aula 6.1 — Histórico com prazo de validade: forecast probabilístico e o painel de board com Trust Velocity
+Meta: id=`forecast-pos-ia-metricas-de-board` | duracao=`20 min` | icone=`bar-chart`
+Descrição: Por que o histórico de velocity vira fóssil estatístico quando o regime muda, como montar um forecast em camadas com confiança P50-P75 e qual painel de quinze métricas substitui story points na conversa com o board.
+
+### [text]
+Com agentes de IA no delivery, o histórico de produtividade tem prazo de validade: a distribuição estatística muda sempre que muda o regime — modelo, prompt, workflow, budget. A resposta não é abandonar previsão, e sim encurtá-la e torná-la probabilística: forecast em camadas (7-14 dias, 4-6 semanas, 3 meses) e um painel de board centrado em **Trust Velocity** — mudanças verificadas por unidade de tempo, custo e risco.
+
+Você provavelmente já viveu isso no modelo antigo: três meses de velocity estável davam uma base razoável para prometer um trimestre. Na era agentic, esse mesmo histórico pode ser um **fóssil estatístico**. O motivo é estrutural, não circunstancial: com agentes, a distribuição que gera seus números muda toda vez que muda o regime de execução.
+
+O documento-fonte cataloga onze fatores que alteram o regime — e, portanto, invalidam o histórico bruto:
+
+-- Modelo utilizado
+-- Modo de execução (assistido, agentic, orquestrado)
+-- Prompt padrão
+-- Workflow de orquestração
+-- Ferramenta em uso
+-- Servidores MCP conectados
+-- Suíte de testes
+-- Política de permissão dos agentes
+-- Cobertura de contexto disponível para o agente
+-- Estratégia de orquestração (subagentes, revisão adversarial)
+-- Budget de tokens por tarefa
+
+> Se qualquer um desses onze fatores mudou no último mês, seu histórico de três meses não descreve o sistema que você opera hoje. Comprometer prazo em cima dele é falsa precisão.
+
+Segundo o DORA 2025, a IA é um **amplificador das forças e fraquezas organizacionais** — o maior ROI não vem da ferramenta isolada, mas do sistema organizacional subjacente. Essa é a moldura executiva. Um sistema de forecast frágil, amplificado por agentes, produz promessas mais rápidas e igualmente erradas.
+
+### [text]
+A solução do documento-fonte é o **forecast pós-IA em camadas**, com pesos decrescentes conforme a distância do regime atual:
+
+| Janela de dados | Papel no forecast | Como usar |
+|---|---|---|
+| Últimos 7-14 dias | Regime atual | Base primária: reflete modelo, prompts e workflow vigentes |
+| Últimas 4-6 semanas | Forecast operacional | Compromissos de curto prazo com bandas de confiança |
+| Últimos 3 meses | Referência contextual | Contexto e sazonalidade — nunca base de compromisso |
+| Pré-mudança grande de regime | Arquivo histórico | Registro para auditoria, não insumo de previsão |
+
+Sobre essa base, o **roadmap board-ready** troca a lista de features com datas por uma tabela fiduciária: frente × outcome × KPI × janela × confiança (P50-P75) × risco × **evidence gate**. Cada linha declara o que será entregue, como se mede, com que probabilidade e qual evidência destrava a próxima etapa.
+
+A conversa com o stakeholder muda de gramática. Sai "entregamos X no dia Y"; entra "temos P75 de entregar este outcome nesta janela, desde que os evidence gates sejam cumpridos". É menos teatral — e mais fiduciário, porque expõe incerteza em vez de escondê-la.
+
+O DORA e o Google Cloud (2025) sustentam a urgência dessa tradução: ganhos de velocidade em coding **não se convertem automaticamente em resultado financeiro** — líderes precisam conectar engenharia, valor e outcomes. O roadmap board-ready é exatamente esse conector.
+
+### [tip]
+Não tente implantar as camadas e o painel inteiro de uma vez. Escolha duas frentes do roadmap atual, reescreva-as no formato board-ready com confiança P50-P75 e apresente ao seu par de produto antes da reunião de board. As objeções que surgirem revelam onde falta evidence gate — e esse diagnóstico vale mais do que o template preenchido.
+
+### [text]
+O painel AI-native do documento-fonte tem quinze métricas, organizadas em torno de uma métrica-mãe:
+
+> "Trust Velocity = mudanças verificadas por unidade de tempo, custo e risco." — Alexandre Caramaschi, documento-fonte
+
+As quinze métricas do painel:
+
+-- **Trust Velocity** — a métrica-mãe: quanto resultado verificado o sistema produz
+-- **Cost per Verified Change** e **Token Burn Rate** — a dimensão econômica
+-- **Validation Debt** e **AI Delivery Drag** — o passivo de verificação acumulado
+-- **Model Mix Efficiency** — se o roteamento de modelos (Módulo 2) está correto
+-- **Regression Rate**, **Change Failure Rate** e **Deployment Rework Rate** — a estabilidade
+-- **Evidence Completeness**, **Test Review Coverage** e **Spec Clarity Score** — a qualidade dos insumos e das provas
+-- **Prompt/Agent Drift Score** e **Safety Near Misses** — o comportamento dos agentes
+-- **Estimate TTL Breach** — quantas estimativas venceram antes da entrega
+
+Nenhuma delas é story point. Todas respondem às perguntas que o board deveria fazer no lugar de "quantos pontos entregamos?" — quantas mudanças verificadas saíram, a que custo, com que taxa de regressão, com quanta dívida de validação. O documento-fonte lista nove dessas perguntas; a lição executiva é que o painel existe para respondê-las, não para decorar slide.
+
+Repare também na conexão entre o painel e o forecast: **Estimate TTL Breach** mede quantas estimativas venceram antes da entrega — ou seja, quantas vezes o regime mudou mais rápido do que a previsão feita sobre ele. Quando essa métrica sobe, o sinal não é "o time estima mal"; é que a janela de forecast precisa encurtar. O painel e as camadas de previsão são o mesmo sistema visto de dois ângulos: um mede, o outro promete.
+
+### [checkpoint]
+-- **Exercício 1 — Roadmap board-ready.** Reescreva as 3 frentes principais do seu roadmap atual — um cenário real da sua operação, não um exemplo de laboratório — no formato frente × outcome × KPI × janela × confiança (P50-P90) × risco × evidence gate. Apresente ao seu par de produto e registre as objeções — cada objeção aponta um gate mal definido.
+-- **Exercício 2 — Painel mínimo.** Das quinze métricas, selecione as 5 que sua organização consegue medir em 30 dias com dados existentes (Regression Rate, Change Failure Rate e Token Burn Rate costumam já ter fonte) e defina a fórmula operacional de cada uma, com origem do dado e dono da medição.
+
+## Aula 6.2 — Tiny teams e as cinco camadas do Agentic Operating Model: Intent, Spec, Orchestration, Verification, Governance
+Meta: id=`tiny-teams-operating-model-cinco-camadas` | duracao=`20 min` | icone=`layers`
+Descrição: Squads continuam existindo, mas mudam de propósito: menores, muito mais sofisticados, com seis novas capacidades, operando um modelo de cinco camadas onde nascem previsibilidade, alavancagem, confiança e escala.
+
+### [text]
+Tiny teams não são corte de custo: são squads menores e muito mais sofisticados, que trocam distribuição de tarefas por garantia de contexto e accountability. Segundo a Gartner, até 2029, 60% das organizações adotarão tiny software engineering teams em escala, contra 15% em 2026. Esses times operam um modelo de cinco camadas — Intent, Spec, Orchestration, Verification, Governance — sustentado por seis novas capacidades.
+
+A provocação que abre a aula vem do próprio documento-fonte: se uma pessoa com agentes entrega ponta a ponta, squads ainda fazem sentido? A resposta é sim — mas não como antes. O squad deixa de ser um pool de capacidade de codificação e vira uma unidade de **ownership, contexto e governança**.
+
+Os números do Gartner dimensionam a transição: os times de referência têm 4-5 pessoas hoje e podem chegar a 2-3 conforme skills e IA amadurecem. A condição que costuma ser ignorada: tiny teams **exigem platform teams** e capacidades novas — PM, UX/AX designer, AI-native software engineer. Encolher o squad sem construir a plataforma embaixo é demissão disfarçada de estratégia.
+
+### [text]
+O documento-fonte descreve o novo squad em sete transições de propósito:
+
+| Squad tradicional | Squad AI-native |
+|---|---|
+| Distribui tarefas entre devs | Garante contexto e accountability |
+| QA valida no fim | Validação nasce na spec |
+| Tech Lead revisa código | Tech Lead revisa arquitetura, testes e risco |
+| Capacidade medida em pessoas | Capacidade medida em orquestração e verificação |
+| Estima esforço | Estima risco, validação e confiança |
+| Rituais de status | Inspeção de evidências e agent runs |
+| Cresce contratando | Cresce sofisticando plataforma e agentes |
+
+Sustentando essas transições, seis novos papéis — **capacidades, não cargos**:
+
+-- **Intent Architect** — transforma problema de negócio em spec verificável
+-- **Agent Orchestrator** — desenha workflow, escolhe modelos, define permissões
+-- **Validation Engineer** — constrói harnesses, evals e evidence gates
+-- **AI Unit Economist** — mede custo, token e model mix por outcome
+-- **Agent Safety Lead** — mantém guardrails e circuit breakers
+-- **Outcome Auditor** — verifica o valor real da entrega, não a atividade
+
+### [tip]
+Trate os seis papéis como chapéus, não como headcount. Em um squad de quatro pessoas, uma pessoa acumula duas ou três capacidades, e parte delas pode ser parcialmente agentic (um agente de evals cobre metade do trabalho do Validation Engineer). O erro caro é a capacidade descoberta: ninguém responde por unit economics ou por safety, e a lacuna só aparece no incidente. Avalie se, no seu squad atual, alguma das seis está sem dono — essa é a primeira lacuna a fechar.
+
+### [text]
+As capacidades operam dentro do **Agentic Operating Model em cinco camadas** — a arquitetura que consolida todo o curso:
+
+| Camada | O que nasce nela | Módulo de origem |
+|---|---|---|
+| Intent Layer | Direção — intenção clara e critérios de sucesso | M1, M5 |
+| Spec Layer | Previsibilidade — specs verificáveis, Spec Acceptance Pack | M5 |
+| Agent Orchestration Layer | Alavancagem — model routing, subagentes, workflows | M2 |
+| Verification Layer | Confiança — Quality Evidence Stack, Definition of Verified, evals | M3, M4 |
+| Governance Layer | Escala corporativa — autonomia L0-L5, guardrails, auditoria | M5 |
+
+> "Sem intenção clara, agente só acelera ambiguidade." — Alexandre Caramaschi, documento-fonte, sobre a Camada 1
+
+A ordem das camadas importa. Orquestração sem spec produz volume sem previsibilidade; verificação sem governança produz confiança que não escala. E o risco de pular a última camada tem número: o Gartner estima que até 2027, 40% das empresas descomissionarão ou rebaixarão agentes autônomos por falhas de governança. O fecho do documento-fonte resume o trade-off: o squad AI-native é menor, mas precisa ser muito mais sofisticado.
+
+Cada camada também nomeia o que ela entrega ao negócio: na Intent Layer nasce a direção; na Spec Layer, a previsibilidade; na Orchestration Layer, a alavancagem; na Verification Layer, a confiança; na Governance Layer, a escala corporativa. Quando um executivo pergunta "onde investir primeiro?", a resposta operacional é: na camada mais fraca do seu diagnóstico — porque o valor das camadas de cima é limitado pela camada que falta embaixo.
+
+### [checkpoint]
+-- **Exercício 3 — Matriz papéis × pessoas.** Distribua as seis capacidades novas entre os membros reais de um squad seu (uma pessoa pode acumular; capacidade pode ser parcialmente agentic). Identifique a capacidade descoberta e escreva em duas frases o custo de deixá-la vaga por mais um trimestre.
+-- **Exercício 4 — Diagnóstico de camadas.** Avalie sua organização de 0 a 5 em cada uma das cinco camadas do operating model e defina a iniciativa única de maior alavancagem para a camada mais fraca — tipicamente Verification ou Governance. Justifique por que ela destrava as demais.
+
+## Aula 6.3 — A nova cadência operacional: IA não matou Agile — matou o Agile performático
+Meta: id=`cadencia-operacional-fim-do-agile-performatico` | duracao=`20 min` | icone=`calendar-clock`
+Descrição: Do daily ao quarterly, a cadência agentic substitui rituais de status por inspeção de agent runs, Evidence Manifests e recalibração de regime — e o veredito final separa o que morre (sprint como teatro) do que sobrevive (empirismo, fluxo, feedback).
+
+### [text]
+A IA não eliminou a cadência operacional — eliminou os rituais performáticos. A cadência agentic opera em cinco ritmos: daily (bloqueios, aging, agent runs críticos), end-of-day (Nightly Agentic Verification e Evidence Manifest), weekly (tail review, validation debt, reforecast), monthly (guardrails e produtividade real) e quarterly (portfólio por outcomes e unit economics). Sobrevive o empirismo; morre o teatro.
+
+O ponto de partida andragógico: você não precisa de mais reuniões — precisa que as reuniões existentes inspecionem coisas diferentes. A tabela abaixo, do documento-fonte, redefine cada ritmo:
+
+| Ritmo | O que se inspeciona na cadência agentic |
+|---|---|
+| Daily | Bloqueios, aging de itens, agent runs críticos da noite anterior |
+| End-of-day | Orquestrador roda testes impactados, suíte, E2E, security scan; gera Evidence Manifest e revisão adversarial |
+| Weekly | Tail review (P85/P90), validation debt, reforecast, calibração de model routing |
+| Monthly | Guardrails, near misses, produtividade real vs percebida, atualização da Definition of Verified |
+| Quarterly | Portfólio por outcomes, tiny teams, unit economics, decisão build/buy/agentic arbitrage |
+
+O daily deixa de ser status report — os agentes reportam status por telemetria — e vira triagem de risco. O end-of-day institucionaliza a prática do Módulo 4: a máquina valida à noite, o humano revisa evidências pela manhã. A decisão quarterly de build/buy ganha um insumo novo: o Gartner estima até US$ 234 bilhões em gastos corporativos com SaaS de aplicações empresariais expostos ao **agentic arbitrage** até 2030 — cada renovação de contrato agora compete com um agente executando o mesmo outcome.
+
+O weekly merece atenção especial porque é onde o operating model se recalibra: o tail review de P85/P90 expõe os itens que envelhecem na cauda da distribuição, o estoque de validation debt diz se a verificação está acompanhando a geração, e a calibração de model routing corrige o mix de modelos antes que o custo derive. É a reunião que substitui a sprint review — inspeciona evidências e regime, não demos ensaiadas.
+
+### [text]
+A conclusão 20.1 do documento-fonte é o veredito do curso — e exige separar com precisão o que morre do que sobrevive:
+
+| Morre (Agile performático) | Sobrevive (empirismo real) |
+|---|---|
+| Sprint como teatro de comprometimento | Inspeção e adaptação sobre evidências |
+| Story point como contrato | Fluxo, WIP e lead time |
+| Roadmap como ficção determinística | Forecast probabilístico por regime |
+| Daily como status report | Daily como triagem de bloqueios e agent runs |
+| Code review como gargalo cego de volume | Revisão de evidências, proporcional ao risco |
+| "Done" sem evidência | Definition of Verified com Evidence Manifest |
+| Retrospectiva ritualística | Retrospectiva sobre validation debt e near misses |
+
+> "IA não matou Agile. Matou a falsa precisão." — Alexandre Caramaschi, documento-fonte
+
+Note o que a coluna da direita preserva: empirismo, fluxo, feedback, WIP, lead time, retrospectiva, inspeção, adaptação. São os fundamentos que o Agile sempre reivindicou — agora operando em cima de agentes, com evidência no lugar de cerimônia. Quem lê essa tabela como "abandone o Scrum" errou o diagnóstico; quem lê como "pare de fingir precisão" acertou.
+
+O ceticismo humano continua sendo insumo, não obstáculo: segundo o Stack Overflow Survey 2025, 46% dos desenvolvedores desconfiam ativamente da precisão de ferramentas de IA, contra 33% que confiam — e os mais experientes são os mais céticos. A cadência agentic canaliza essa desconfiança para os pontos de maior risco, em vez de dissolvê-la em rituais.
+
+### [tip]
+Implante a cadência por fatia, não por decreto — é um recorte que você pode aplicar sem pedir aprovação do board. Rode por duas semanas apenas o end-of-day (orquestrador de testes + Evidence Manifest + revisão matinal de 15 minutos) e o weekly (validation debt + reforecast). Meça o delta de retrabalho nessas duas semanas e use o número — não o argumento — para expandir aos demais ritmos.
+
+### [text]
+O fechamento amarra as sete conclusões do documento-fonte em um único sistema operacional:
+
+-- **Validação é o novo gargalo estratégico** (20.3): o gargalo não é gerar código — é provar que funciona, não quebrou nada, respeita arquitetura, não cria vulnerabilidade, performa, é reversível e cumpre a intenção
+-- **TDD como controle de agente** (20.2) e **Agent Evaluation Engineering** (20.4): o teste é contrato, o eval é o teste do agente
+-- **O humano como auditor de intenção e risco** (20.5): revisa spec, evidências e blast radius — não linha a linha
+-- **Model routing como vantagem competitiva** (20.6): o modelo certo, na etapa certa, com a permissão certa, pelo custo certo
+
+A síntese da seção 21: o novo operating model = spec-first + TDD/evals + model routing + validation engineering + governança proporcional ao risco + forecast probabilístico. Cada termo dessa equação foi um módulo deste curso; a cadência desta aula é o que os faz girar juntos, semana após semana.
+
+> "Na era dos agentes, não ganha quem gera mais código; ganha quem transforma intenção em resultado verificado, com menor custo, menor risco e maior velocidade de confiança." — Alexandre Caramaschi, documento-fonte, frase final
+
+### [checkpoint]
+-- **Exercício 5 — Piloto de cadência.** Implemente por 2 semanas apenas o end-of-day (orquestrador de testes + Evidence Manifest + revisão matinal de 15 min) e o weekly (validation debt + reforecast). Documente o delta de retrabalho e apresente o caso interno para expandir aos demais ritmos — com número, não com narrativa.
+-- **Exercício 6 — Plano de 90 dias.** Consolide o curso em um roadmap de adoção com 3 marcos mensais — mês 1: Definition of Verified + checklist no PR; mês 2: model routing + autonomia L0-L5; mês 3: painel com 5 métricas + forecast em camadas. Defina o evidence gate de cada marco: qual prova precisa existir para declarar o marco cumprido.


### PR DESCRIPTION
## O que muda

- Registra o curso **"O Novo Mundo de Fazer Software: do Agile ao Agentic Operating Model"** (slug `agentic-operating-model`, 6 módulos / 18 aulas, ~360 min, P0) em `config/courses.yaml`, com `estrutura_modulos` completa.
- Versiona os 6 drafts em `output/drafts/agentic-operating-model/` — redigidos por agentes a partir do documento-fonte "O novo mundo de fazer software no 2º semestre de 2026" e **aprovados no quality gate local** (`python cli.py validate`): acentuação, conteúdo (Bloom, andragogia, exercícios), citabilidade GEO (Cite Sources ≥3, Statistics ≥5, Quotation ≥1, answer capsules).

## Evidência de validação

- Gate final por módulo: zero erros reais; restam apenas falsos positivos documentados — `'AI'→'aí'` em nomes próprios (NIST AI RMF, Gen AI, AI Delivery Drag) e `'ele'→'ele'` (bug do ACCENT_MAP, linha 47 do accent_checker: entrada marcada "excluir" nunca removida).
- Nenhum dado inventado: todas as estatísticas/citações rastreiam ao documento-fonte (Gartner, McKinsey, DORA 2025, NIST, OWASP, Fowler, Stack Overflow 2025, arXiv TDAD).

## Curso publicado

Página TSX correspondente em PR no repo landing-page-geo (`/educacao/agentic-operating-model`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)