### PR TITLE
feat(B-019): backend LLM via geo_orchestrator_sdk atras de env flag (opt-in)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,14 @@ FINOPS_LIMIT_ANTHROPIC=8.00
 # Cache
 CACHE_DIR=.cache
 CACHE_TTL_HOURS=24
+
+# --- Backend LLM (B-019/D8, opt-in) ------------------------------------------
+# "sdk" roteia todas as chamadas LLM pelo geo_orchestrator_sdk: herda banda de
+# timeout por task_type (research 600s...), fallback chain canonica, circuit
+# breaker e FinOps unificado do orquestrador. Ausente/qualquer outro valor =
+# backend legado (zero mudanca). Requer o clone do geo-orchestrator.
+# CURSO_FACTORY_LLM_BACKEND=sdk
+# GEO_ORCHESTRATOR_PATH=C:\Users\SEU_USUARIO\geo-orchestrator
+
+# Timeout de leitura HTTP do backend legado (segundos; default 600)
+# HTTP_TIMEOUT=600

--- a/src/llm_client.py
+++ b/src/llm_client.py
@@ -317,3 +317,25 @@ class LLMClient:
 
     def call_anthropic(self, prompt: str, **kwargs: Any) -> str:
         return self.call("anthropic", prompt, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Factory de backend (B-019/D8 — strangler pattern, 2026-07-09)
+# ---------------------------------------------------------------------------
+
+def make_llm_client(
+    cost_tracker: CostTracker | None = None,
+    cache: Cache | None = None,
+    use_cache: bool = True,
+):
+    """Retorna o cliente LLM do backend ativo.
+
+    CURSO_FACTORY_LLM_BACKEND=sdk -> SDKLLMClient (geo_orchestrator_sdk):
+    herda banda de timeout por task_type, fallback chain canonica, circuit
+    breaker e FinOps unificado do orquestrador. Qualquer outro valor (ou
+    ausente) -> LLMClient legado (zero mudanca de comportamento).
+    """
+    if os.getenv("CURSO_FACTORY_LLM_BACKEND", "").strip().lower() == "sdk":
+        from src.llm_client_sdk import SDKLLMClient
+        return SDKLLMClient(cost_tracker=cost_tracker, cache=cache, use_cache=use_cache)
+    return LLMClient(cost_tracker=cost_tracker, cache=cache, use_cache=use_cache)

--- a/src/llm_client_sdk.py
+++ b/src/llm_client_sdk.py
@@ -1,0 +1,173 @@
+"""Backend LLM via geo_orchestrator_sdk — B-019/D8 (strangler pattern).
+
+O curso-factory sempre chamou as APIs LLM direto (httpx proprio) — bypass do
+orquestrador: sem banda de timeout por task_type, sem fallback chain canonica,
+sem FinOps unificado (o incidente de timeout do research em sonar-pro nasceu
+desse bypass). Este adapter implementa a MESMA interface do LLMClient legado
+(`call(provider, prompt, **kwargs) -> str` + atalhos + course context) mas
+delega ao `geo_orchestrator_sdk.call_llm`, herdando:
+
+- banda de timeout por task_type (research 600s, writing 420s...);
+- fallback chain canonica do orquestrador + circuit breaker;
+- FinOps global (mesmo ledger diario SQLite dos runs do orquestrador),
+   alem do cost_tracker LOCAL por course_id (dupla contabilidade mantida).
+
+ATIVACAO (opt-in, rollout seguro — zero mudanca sem a env):
+
+    CURSO_FACTORY_LLM_BACKEND=sdk
+
+O caminho do repo do orquestrador vem de GEO_ORCHESTRATOR_PATH (default:
+~/geo-orchestrator). A troca acontece na factory `make_llm_client()` em
+llm_client.py — os agents nao mudam (mesma interface).
+
+Diferencas deliberadas vs legado (documentadas, nao acidentais):
+- `model=` custom e IGNORADO com log: o catalog do orquestrador e a SoT de
+  modelos (sempre a versao canonica mais atual de cada provider).
+- retry/backoff por chamada sao do orquestrador (LLMClient interno), nao os
+  `max_retries/base_delay` locais — aceitos e ignorados com log.
+- cache local do curso-factory continua valendo (envolve o adapter no mesmo
+  ponto do fluxo: aqui dentro, antes de delegar).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from src.cache import Cache
+from src.cost_tracker import CostTracker
+
+logger = logging.getLogger(__name__)
+
+# provider (curso-factory) -> (alias canonico, task_type) no orquestrador.
+# task_type governa a BANDA DE TIMEOUT e a fallback chain herdadas.
+PROVIDER_TO_SDK: dict[str, tuple[str, str]] = {
+    "perplexity": ("perplexity", "research"),    # sonar-deep-research, 600s
+    "openai":     ("gpt4o", "writing"),          # gpt-5.5, 420s
+    "google":     ("gemini", "analysis"),        # gemini pro, 360s
+    "anthropic":  ("claude", "review"),          # opus, 360s
+    # groq foi removido do orquestrador (Sprint 16); o equivalente bulk
+    # canonico e o gemini_flash. Mantido para compat com fluxos legados.
+    "groq":       ("gemini_flash", "classification"),
+}
+
+
+def _ensure_sdk_on_path() -> None:
+    """Adiciona o repo do geo-orchestrator ao sys.path (path-based install)."""
+    root = Path(
+        os.environ.get("GEO_ORCHESTRATOR_PATH", str(Path.home() / "geo-orchestrator"))
+    )
+    if not (root / "geo_orchestrator_sdk" / "__init__.py").exists():
+        raise ImportError(
+            f"geo_orchestrator_sdk nao encontrado em {root} — defina "
+            "GEO_ORCHESTRATOR_PATH apontando para o clone do geo-orchestrator."
+        )
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+
+
+class SDKLLMClient:
+    """Drop-in do LLMClient legado, delegando ao geo_orchestrator_sdk.
+
+    Mesma superficie usada pelos agents: call(), atalhos call_<provider>(),
+    set_course_context(), close(), context manager e cost_tracker local.
+    """
+
+    def __init__(
+        self,
+        cost_tracker: CostTracker | None = None,
+        cache: Cache | None = None,
+        use_cache: bool = True,
+    ) -> None:
+        _ensure_sdk_on_path()
+        from geo_orchestrator_sdk import call_llm  # noqa: PLC0415
+
+        self._call_llm = call_llm
+        self.cost_tracker = cost_tracker or CostTracker()
+        self.cache = cache if cache is not None else (Cache() if use_cache else None)
+        self.current_course_id: str = ""
+        logger.info("LLM backend: geo_orchestrator_sdk (CURSO_FACTORY_LLM_BACKEND=sdk)")
+
+    # --- interface legada -------------------------------------------------
+
+    def set_course_context(self, course_id: str) -> None:
+        self.current_course_id = course_id or ""
+
+    def close(self) -> None:
+        """No-op: o SDK fecha o ConnectionPool por chamada (licao F3)."""
+
+    def __enter__(self) -> "SDKLLMClient":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    def call(self, provider: str, prompt: str, **kwargs: Any) -> str:
+        if provider not in PROVIDER_TO_SDK:
+            raise ValueError(
+                f"provider desconhecido: {provider!r} (validos: {sorted(PROVIDER_TO_SDK)})"
+            )
+        alias, task_type = PROVIDER_TO_SDK[provider]
+
+        # Compat: kwargs do backend legado que o SDK governa internamente.
+        for ignored in ("model", "max_retries", "base_delay", "_fallback_depth"):
+            if ignored in kwargs:
+                logger.debug(
+                    "SDK backend ignora kwarg %r=%r (governado pelo orquestrador)",
+                    ignored, kwargs.pop(ignored),
+                )
+        max_tokens = int(kwargs.pop("max_tokens", 4096))
+        if kwargs:
+            logger.debug("SDK backend: kwargs nao mapeados ignorados: %s", sorted(kwargs))
+
+        # Cache local do curso-factory (mesma posicao do fluxo legado).
+        if self.cache is not None:
+            cached = self.cache.get(prompt, provider, alias)
+            if cached is not None:
+                return cached
+
+        result = self._call_llm(
+            prompt, task_type=task_type, alias=alias, max_tokens=max_tokens
+        )
+
+        # Dupla contabilidade: FinOps global ja registrado pelo SDK; aqui o
+        # ledger LOCAL por curso (relatorios por course_id continuam integros).
+        self.cost_tracker.track(
+            provider,
+            result.tokens_input,
+            result.tokens_output,
+            result.model,
+            result.cost,
+            course_id=self.current_course_id,
+        )
+        logger.info(
+            "LLM(sdk) %s->%s/%s: %d tok_in, %d tok_out, USD %.4f (curso=%s%s)",
+            provider, result.alias, result.model,
+            result.tokens_input, result.tokens_output, result.cost,
+            self.current_course_id or "n/a",
+            ", fallback" if result.fallback_used else "",
+        )
+
+        if self.cache is not None:
+            self.cache.set(prompt, provider, alias, result.text)
+        return result.text
+
+    # --- atalhos legados ---------------------------------------------------
+
+    def call_perplexity(self, prompt: str, **kwargs: Any) -> str:
+        return self.call("perplexity", prompt, **kwargs)
+
+    def call_openai(self, prompt: str, **kwargs: Any) -> str:
+        return self.call("openai", prompt, **kwargs)
+
+    def call_google(self, prompt: str, **kwargs: Any) -> str:
+        return self.call("google", prompt, **kwargs)
+
+    def call_groq(self, prompt: str, **kwargs: Any) -> str:
+        return self.call("groq", prompt, **kwargs)
+
+    def call_anthropic(self, prompt: str, **kwargs: Any) -> str:
+        return self.call("anthropic", prompt, **kwargs)

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -66,7 +66,11 @@ class Orchestrator:
             from src.clients import load_client
             client_context = load_client("default")
         self.client_context = client_context
-        self.client = LLMClient(self.cost_tracker)
+        # B-019/D8: factory decide o backend — legado (default) ou
+        # geo_orchestrator_sdk via CURSO_FACTORY_LLM_BACKEND=sdk (herda
+        # timeout por task_type, fallback chain e FinOps do orquestrador).
+        from src.llm_client import make_llm_client
+        self.client = make_llm_client(self.cost_tracker)
         self.researcher = Researcher(self.client)
         self.writer = Writer(self.client)
         self.analyzer = Analyzer(self.client)

--- a/tests/test_llm_client_sdk.py
+++ b/tests/test_llm_client_sdk.py
@@ -1,0 +1,133 @@
+"""Backend SDK (B-019/D8) — factory + adapter drop-in.
+
+O adapter delega ao geo_orchestrator_sdk.call_llm; aqui o call_llm e mockado
+(sem rede). O import real do SDK e coberto quando GEO_ORCHESTRATOR_PATH/
+~/geo-orchestrator existe; caso contrario os testes de adapter sao pulados
+(CI sem o repo vizinho) — a factory legada roda sempre.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.cost_tracker import CostTracker
+from src.llm_client import LLMClient, make_llm_client
+
+_SDK_ROOT = Path(
+    os.environ.get("GEO_ORCHESTRATOR_PATH", str(Path.home() / "geo-orchestrator"))
+)
+_HAS_SDK = (_SDK_ROOT / "geo_orchestrator_sdk" / "__init__.py").exists()
+
+needs_sdk = pytest.mark.skipif(
+    not _HAS_SDK, reason="geo-orchestrator nao disponivel neste ambiente"
+)
+
+
+@dataclass
+class _FakeResult:
+    text: str = "resposta sdk"
+    alias: str = "perplexity"
+    model: str = "sonar-deep-research"
+    provider: str = "perplexity"
+    cost: float = 0.002
+    tokens_input: int = 100
+    tokens_output: int = 50
+    citations: list = field(default_factory=list)
+    fallback_used: bool = False
+
+
+def test_factory_default_is_legacy(monkeypatch):
+    monkeypatch.delenv("CURSO_FACTORY_LLM_BACKEND", raising=False)
+    client = make_llm_client(use_cache=False)
+    try:
+        assert isinstance(client, LLMClient)
+    finally:
+        client.close()
+
+
+def test_factory_unknown_value_is_legacy(monkeypatch):
+    monkeypatch.setenv("CURSO_FACTORY_LLM_BACKEND", "banana")
+    client = make_llm_client(use_cache=False)
+    try:
+        assert isinstance(client, LLMClient)
+    finally:
+        client.close()
+
+
+@needs_sdk
+def test_factory_sdk_backend(monkeypatch):
+    monkeypatch.setenv("CURSO_FACTORY_LLM_BACKEND", "sdk")
+    from src.llm_client_sdk import SDKLLMClient
+    client = make_llm_client(use_cache=False)
+    assert isinstance(client, SDKLLMClient)
+
+
+@needs_sdk
+class TestSDKAdapter:
+    def _client(self, use_cache=False):
+        from src.llm_client_sdk import SDKLLMClient
+        tracker = CostTracker()
+        c = SDKLLMClient(cost_tracker=tracker, use_cache=use_cache)
+        return c, tracker
+
+    def test_call_maps_provider_and_tracks_cost(self):
+        c, tracker = self._client()
+        captured = {}
+
+        def fake_call_llm(prompt, *, task_type, alias, max_tokens):
+            captured.update(task_type=task_type, alias=alias, max_tokens=max_tokens)
+            return _FakeResult()
+
+        c._call_llm = fake_call_llm
+        c.set_course_context("curso-teste")
+        with patch.object(tracker, "track") as track:
+            out = c.call("perplexity", "pesquise algo", max_tokens=2048)
+        assert out == "resposta sdk"
+        # research herda a banda de 600s no lado do orquestrador
+        assert captured == {"task_type": "research", "alias": "perplexity",
+                            "max_tokens": 2048}
+        kw = track.call_args.kwargs
+        assert track.call_args.args[0] == "perplexity"
+        assert kw.get("course_id") == "curso-teste"
+
+    def test_legacy_kwargs_ignored_not_fatal(self):
+        c, _ = self._client()
+        c._call_llm = lambda prompt, **kw: _FakeResult()
+        out = c.call("openai", "escreva", model="gpt-4o-custom",
+                     max_retries=9, base_delay=1.0)
+        assert out == "resposta sdk"
+
+    def test_unknown_provider_raises(self):
+        c, _ = self._client()
+        with pytest.raises(ValueError, match="provider desconhecido"):
+            c.call("cohere", "oi")
+
+    def test_local_cache_hit_skips_sdk(self, tmp_path):
+        from src.llm_client_sdk import SDKLLMClient
+        from src.cache import Cache
+        cache = Cache(ttl=3600)
+        cache._dir = tmp_path  # isola do cache real em disco
+        c = SDKLLMClient(cache=cache)
+        calls = []
+
+        def fake(prompt, **kw):
+            calls.append(prompt)
+            return _FakeResult()
+
+        c._call_llm = fake
+        a = c.call("google", "analise X")
+        b = c.call("google", "analise X")
+        assert a == b == "resposta sdk"
+        assert len(calls) == 1, "segunda chamada devia vir do cache local"
+
+    def test_provider_map_covers_legacy_surface(self):
+        from src.llm_client_sdk import PROVIDER_TO_SDK
+        for p in ("perplexity", "openai", "google", "anthropic", "groq"):
+            assert p in PROVIDER_TO_SDK
+        # timeouts herdados: research para o canal que estourava 60s
+        assert PROVIDER_TO_SDK["perplexity"] == ("perplexity", "research")


### PR DESCRIPTION
D8 do plano CTO-Fable — strangler pattern com rollout seguro: SDKLLMClient drop-in (mesma interface call/atalhos/course-context) delegando ao geo_orchestrator_sdk.call_llm, atras de CURSO_FACTORY_LLM_BACKEND=sdk (default = legado, ZERO mudanca sem opt-in). Herda do orquestrador: banda de timeout por task_type (research 600s — o canal do incidente de timeout), fallback chain canonica, circuit breaker e FinOps unificado; cost_tracker local por course_id e cache local preservados. A viabilizacao exigiu fix no proprio SDK (colisao de namespace src com consumidores — resolvida por alias de modulo; geo-orchestrator @ Sprint 22, commits 525dbcb+). Testes: 8 novos; suite 240 passed com as mesmas 5 falhas pre-existentes do main limpo (baseline verificado por stash). Ativacao sugerida: 1 curso de teste com a env ligada antes de virar default.