### PR TITLE
docs: add humanized editorial standard to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -321,3 +321,36 @@ python cli.py batch config/courses.yaml --client X   # Lote sob cliente X
 - NUNCA usar: "Especialista #1", credenciais inventadas
 
 **Para outro cliente:** consulte `config/clients/<id>/client.yaml` → seção `author:` e `voice_guard.canonical:`. O voice guard bloqueia textos que violem o naming canônico do cliente ativo.
+
+## Padrão editorial — escrita humanizada (17/07/2026)
+
+Todo conteúdo de leitura humana produzido neste repo (artigo, curso, página, post,
+e-mail, relatório, parecer, resposta ao usuário) segue o padrão editorial global do
+Alexandre. Qualidade vence velocidade; profundidade proporcional ao problema;
+escrever como especialista sênior conversando com outro profissional experiente.
+Fonte de verdade completa: `docs/ESTILO_EDITORIAL.md` do repo GEO-Pesquisador
+(clone local em `C:/Sandyboxclaude/GEO-Pesquisador`).
+
+Proibidos como padrão recorrente (uso pontual e consciente é tolerado):
+
+- Antítese em série: "não se trata de X, trata-se de Y", "não é apenas X, é Y",
+  "não basta X, é preciso Y", "mais do que X, Y". Afirmar direto o que a evidência
+  sustenta.
+- Conectivos batidos repetidos: "além disso", "por outro lado", "nesse contexto",
+  "vale destacar", "é importante ressaltar", "nesse sentido", "por fim".
+- Parágrafos vizinhos abrindo com a mesma construção sintática; blocos com ritmo
+  idêntico; excesso de paralelismo; perguntas retóricas em série; conclusões
+  idênticas fechando tópicos sucessivos.
+- Travessão e hífen como recurso estilístico no conteúdo final: preferir vírgula,
+  dois-pontos ou ponto.
+- Clichês, frases genéricas que serviriam para qualquer assunto, tom promocional,
+  superlativo sem número ao lado, adjetivo decorativo, negrito por hábito.
+
+Obrigatório: linha de raciocínio lógica; cada parágrafo acrescenta uma ideia nova;
+alternar períodos curtos, médios e longos; recomendação sempre acompanhada do
+porquê; conceito técnico coberto com contexto, motivação, funcionamento,
+limitações e critérios de decisão quando relevantes; material educacional abre
+pelo problema e fecha com síntese prática. Antes de entregar, reler procurando
+esses padrões e reescrever o que soar texto de máquina. Sub-agentes que geram
+copy recebem o bloco de `C:/Sandyboxclaude/scripts/prompts/COPY_PROMPT_PREFIX.md`
+carimbado no prompt.


### PR DESCRIPTION
Condensed global editorial standard defined by the curator on 2026-07-17: senior-expert humanized writing, banned generative-writing tics (serial antithesis, repeated stock connectives, uniform paragraph rhythm, stylistic em dash, cliches), proportional technical depth and justified recommendations. Canonical full source: GEO-Pesquisador docs/ESTILO_EDITORIAL.md (commit 27bd872). Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)